### PR TITLE
Add board AI roadmap artifact, schema, validator, and tests

### DIFF
--- a/artifacts/Makefile
+++ b/artifacts/Makefile
@@ -15,7 +15,7 @@ check-all:
 	$(PYTHON) check_all.py --json
 
 test:
-	cd .. && $(PYTHON) -m pytest -q unit_tests/test_artifacts_validation.py
+	cd .. && $(PYTHON) -m pytest -q unit_tests/test_artifacts_validation.py unit_tests/test_validate_board_ai_roadmap.py
 
 # `check-all` already runs semantic validation and manifest verification.
 all: manifest-check check-all test

--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -1,23 +1,39 @@
 # Governance Artifacts Usage Guide
 
-This folder contains machine-readable assets for enterprise and regulator-facing AI governance workflows.
+This folder contains machine-readable assets for enterprise and
+regulator-facing AI governance workflows.
 
 ## Files
 
-- `annex-iv-dossier-schema-v1.json`: JSON Schema for EU AI Act Annex IV dossier payloads.
-- `control-catalog-v1.json`: control inventory with ownership, cadence, severity, and framework mappings.
+- `annex-iv-dossier-schema-v1.json`: JSON Schema for EU AI Act Annex IV
+  dossier payloads.
+- `control-catalog-v1.json`: control inventory with ownership, cadence,
+  severity, and framework mappings.
 - `roadmap-2026-2030.yaml`: phased implementation and milestone plan.
 - `regulator-report-template.xml`: regulator-ready report skeleton.
-- `enterprise-civilizational-agi-asi-blueprint-2026-2030.md`: implementation blueprint narrative.
-- `examples/annex-iv-dossier-example.json`: sample payload conforming to Annex IV schema.
-- `manifest-targets-v1.json`: canonical tracked-file list used by manifest build and validation.
-- `schemas/manifest-targets-schema-v1.json`: JSON Schema for manifest-target metadata.
-- `schemas/artifact-manifest-schema-v1.json`: JSON Schema for produced checksum manifests.
-- `schemas/check-all-result-schema-v1.json`: JSON Schema for unified check JSON output.
-- `artifact-manifest-v1.json`: SHA-256 checksum manifest for tamper-evident packaging.
-- `validate_artifacts.py`: parser + semantic validation utility.
+- `enterprise-civilizational-agi-asi-blueprint-2026-2030.md`:
+  implementation blueprint narrative.
+- `examples/annex-iv-dossier-example.json`: sample payload conforming to
+  Annex IV schema.
+- `artifact-manifest-v1.json`: SHA-256 checksum manifest for tamper-evident
+  packaging.
+- `data/board-ai-roadmap-2026-2030.json`: board roadmap facts (financials,
+  domains, jurisdictions, stage gates).
+- `schemas/board-ai-roadmap-schema-v1.json`: JSON Schema for board roadmap
+  artifact.
+- `validate_board_ai_roadmap.py`: schema validator for board roadmap artifact.
+- `manifest-targets-v1.json`: canonical tracked-file list used by manifest
+  build and validation.
+- `schemas/manifest-targets-schema-v1.json`: JSON Schema for
+  manifest-target metadata.
+- `schemas/artifact-manifest-schema-v1.json`: JSON Schema for produced
+  checksum manifests.
+- `schemas/check-all-result-schema-v1.json`: JSON Schema for unified check
+  JSON output.
+- `validate_artifacts.py`: parser and semantic validation utility.
 - `build_manifest.py`: manifest regeneration utility.
-- `requirements-artifacts.txt`: pinned runtime/test dependencies for artifact checks.
+- `requirements-artifacts.txt`: pinned runtime/test dependencies for artifact
+  checks.
 - `Makefile`: convenience targets for local artifact validation workflows.
 
 ## Validation
@@ -34,23 +50,36 @@ Machine-readable JSON mode:
 python artifacts/validate_artifacts.py --json
 ```
 
+Validate board roadmap artifact:
+
+```bash
+python artifacts/validate_board_ai_roadmap.py
+```
+
 Skip checksum validation (for local editing before manifest regeneration):
 
 ```bash
 python artifacts/validate_artifacts.py --skip-manifest
 ```
 
-On validation failure with `--json`, output is `{ "status": "error", "error": "..." }` and exit code is `1`.
+On validation failure with `--json`, output is:
 
-Exit behavior: all CLI tools return `0` on success and `1` on validation/check failure.
+```json
+{"status": "error", "error": "..."}
+```
+
+Exit behavior: all CLI tools return `0` on success and `1` on
+validation/check failure.
 
 The validator performs:
+
 1. JSON/YAML/XML parse checks.
 2. Required key checks for schema, roadmap, and controls.
-3. Annex IV sample semantic checks (types, required fields, enum values, date format).
+3. Annex IV sample semantic checks (types, required fields, enum values,
+   date format).
 4. Control mapping cross-reference checks (no unknown control IDs).
 5. Regulator XML required section checks.
-6. Roadmap milestone date-range checks (2026–2030).
+6. Roadmap milestone date-range checks (2026-2030).
 7. Manifest checksum checks for all tracked artifacts.
 8. Manifest coverage checks (no missing or unexpected files).
 
@@ -86,7 +115,8 @@ python artifacts/check_all.py
 python artifacts/check_all.py --json
 ```
 
-`check_all --json` includes `schema_version`, `checked_at` (UTC ISO-8601), `manifest_fresh`, `validation_ok`, and `errors`.
+`check_all --json` includes `schema_version`, `checked_at`
+(UTC ISO-8601), `manifest_fresh`, `validation_ok`, and `errors`.
 
 ## Makefile shortcuts
 
@@ -99,6 +129,7 @@ make -C artifacts all
 ```
 
 Other useful shortcuts:
+
 - `make manifest-check`
 - `make validate`
 - `make check-all`
@@ -107,9 +138,13 @@ Other useful shortcuts:
 ## Test
 
 ```bash
-python -m pytest -q unit_tests/test_artifacts_validation.py
+python -m pytest -q unit_tests/test_artifacts_validation.py \
+  unit_tests/test_validate_board_ai_roadmap.py
 # or from artifacts/: make test
 ```
 
-
-CI note: `.github/workflows/artifact-validation.yml` supports `workflow_dispatch` for on-demand re-validation, runs `make -C artifacts all` as the canonical validation entrypoint, and triggers on changes to `artifacts/**`, `unit_tests/**`, `pytest.ini`, and the workflow file itself.
+CI note: `.github/workflows/artifact-validation.yml` supports
+`workflow_dispatch` for on-demand re-validation, runs
+`make -C artifacts all` as the canonical validation entrypoint, and triggers
+on changes to `artifacts/**`, `unit_tests/**`, `pytest.ini`, and the
+workflow file.

--- a/artifacts/artifact-manifest-v1.json
+++ b/artifacts/artifact-manifest-v1.json
@@ -2,11 +2,14 @@
   "files": {
     "annex-iv-dossier-schema-v1.json": "191c3442f4b372e8fb400640648841fb4d63aecdfb791d0b1b230a65a384ffe1",
     "control-catalog-v1.json": "56328ecaed2af4d832e993accb3b85d63d69f93eece4f10de08f0c82f71729d8",
+    "data/board-ai-roadmap-2026-2030.json": "47ce2ce17cfc41f525b96a33c4969370d6cdbf0af37cb4a452fb5792de66843d",
     "enterprise-civilizational-agi-asi-blueprint-2026-2030.md": "12684e460b4f33a49d74e66eaa1400aab85e4dd6879e262e06ac932be7c3f3e3",
     "examples/annex-iv-dossier-example.json": "fd914a07bf2691d9de262907953890ba353b23fe159d07a8b53eee1e6d16b1e2",
     "regulator-report-template.xml": "62c55a96b60bbc4592f0ad273ee1cca6e25eac6a437fb047dfb08bdf5baeab2d",
-    "roadmap-2026-2030.yaml": "2297c95faefe22ff03cb9aa7d104be232fa0269b831cb231f5b7f0ab0ed86369"
+    "roadmap-2026-2030.yaml": "2297c95faefe22ff03cb9aa7d104be232fa0269b831cb231f5b7f0ab0ed86369",
+    "schemas/board-ai-roadmap-schema-v1.json": "bff5e947f78ec5d4d8bb49e8414e077a5d4b8144962272e9720598ddb63ba4dc",
+    "validate_board_ai_roadmap.py": "e2f685259f72771dfcbd48609965f98bbadf219934825518833b9e59c3613954"
   },
-  "generated_at": "2026-04-26T03:26:37+00:00",
+  "generated_at": "2026-04-29T05:06:47+00:00",
   "version": "1.1"
 }

--- a/artifacts/data/board-ai-roadmap-2026-2030.json
+++ b/artifacts/data/board-ai-roadmap-2026-2030.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": "board-ai-roadmap-v1",
+  "program": {
+    "name": "G-SIB AI Transformation",
+    "period": "2026-2030",
+    "investment_usd_billion": 2.8,
+    "value_target_usd_billion": 4.2,
+    "irr_hurdle_percent": 18,
+    "discount_rate_percent": 10
+  },
+  "financials": {
+    "illustrative_net_cash_flows_usd_billion": {
+      "2026": -0.8,
+      "2027": -0.7,
+      "2028": 0.5,
+      "2029": 1.05,
+      "2030": 1.35
+    },
+    "npv_usd_billion": 0.63,
+    "payback_years": 4.2
+  },
+  "domains": [
+    "governance",
+    "infrastructure",
+    "risk_controls",
+    "customer_experience",
+    "operations",
+    "trading_markets"
+  ],
+  "jurisdictions": {
+    "US": [
+      "SR 11-7",
+      "OCC",
+      "CFPB"
+    ],
+    "EU": [
+      "EU AI Act",
+      "GDPR",
+      "EBA guidance"
+    ],
+    "UK": [
+      "PRA",
+      "FCA",
+      "SM&CR",
+      "Operational resilience"
+    ],
+    "APAC": [
+      "MAS FEAT",
+      "HKMA",
+      "Cross-border data governance"
+    ]
+  },
+  "stage_gates": [
+    {
+      "gate": "Gate 1",
+      "target": "2026-Q2",
+      "focus": "Foundation readiness"
+    },
+    {
+      "gate": "Gate 2",
+      "target": "2027-Q2",
+      "focus": "Controlled customer deployment"
+    },
+    {
+      "gate": "Gate 3",
+      "target": "2028-Q4",
+      "focus": "Industrialized compliance"
+    },
+    {
+      "gate": "Gate 4",
+      "target": "2029-Q4",
+      "focus": "High-impact scale"
+    }
+  ]
+}

--- a/artifacts/manifest-targets-v1.json
+++ b/artifacts/manifest-targets-v1.json
@@ -6,6 +6,9 @@
     "roadmap-2026-2030.yaml",
     "regulator-report-template.xml",
     "enterprise-civilizational-agi-asi-blueprint-2026-2030.md",
-    "examples/annex-iv-dossier-example.json"
+    "examples/annex-iv-dossier-example.json",
+    "data/board-ai-roadmap-2026-2030.json",
+    "schemas/board-ai-roadmap-schema-v1.json",
+    "validate_board_ai_roadmap.py"
   ]
 }

--- a/artifacts/requirements-artifacts.txt
+++ b/artifacts/requirements-artifacts.txt
@@ -1,2 +1,3 @@
 pyyaml==6.0.2
 pytest==9.0.3
+jsonschema==4.25.1

--- a/artifacts/schemas/board-ai-roadmap-schema-v1.json
+++ b/artifacts/schemas/board-ai-roadmap-schema-v1.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/board-ai-roadmap-schema-v1.json",
+  "title": "Board AI Roadmap Schema v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "program",
+    "financials",
+    "domains",
+    "jurisdictions",
+    "stage_gates"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "board-ai-roadmap-v1"
+    },
+    "program": {
+      "type": "object",
+      "required": [
+        "name",
+        "period",
+        "investment_usd_billion",
+        "value_target_usd_billion",
+        "irr_hurdle_percent",
+        "discount_rate_percent"
+      ],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "period": {"type": "string", "pattern": "^\\d{4}-\\d{4}$"},
+        "investment_usd_billion": {"type": "number", "minimum": 0},
+        "value_target_usd_billion": {"type": "number", "minimum": 0},
+        "irr_hurdle_percent": {"type": "number", "minimum": 0},
+        "discount_rate_percent": {"type": "number", "minimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "financials": {
+      "type": "object",
+      "required": [
+        "illustrative_net_cash_flows_usd_billion",
+        "npv_usd_billion",
+        "payback_years"
+      ],
+      "properties": {
+        "illustrative_net_cash_flows_usd_billion": {
+          "type": "object",
+          "required": ["2026", "2027", "2028", "2029", "2030"],
+          "additionalProperties": false,
+          "properties": {
+            "2026": {"type": "number"},
+            "2027": {"type": "number"},
+            "2028": {"type": "number"},
+            "2029": {"type": "number"},
+            "2030": {"type": "number"}
+          }
+        },
+        "npv_usd_billion": {"type": "number"},
+        "payback_years": {"type": "number", "minimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "domains": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "jurisdictions": {
+      "type": "object",
+      "required": ["US", "EU", "UK", "APAC"],
+      "additionalProperties": false,
+      "properties": {
+        "US": {"$ref": "#/$defs/nonEmptyStringArray"},
+        "EU": {"$ref": "#/$defs/nonEmptyStringArray"},
+        "UK": {"$ref": "#/$defs/nonEmptyStringArray"},
+        "APAC": {"$ref": "#/$defs/nonEmptyStringArray"}
+      }
+    },
+    "stage_gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["gate", "target", "focus"],
+        "properties": {
+          "gate": {"type": "string", "minLength": 1},
+          "target": {"type": "string", "pattern": "^\\d{4}-Q[1-4]$"},
+          "focus": {"type": "string", "minLength": 1}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyStringArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    }
+  },
+  "additionalProperties": false
+}

--- a/artifacts/validate_artifacts.py
+++ b/artifacts/validate_artifacts.py
@@ -25,8 +25,10 @@ ARTIFACTS_DIR = Path(__file__).resolve().parent
 
 if __package__ in (None, ""):
     from manifest_utils import load_manifest_targets_from_dir, sha256_file
+    from validate_board_ai_roadmap import validate as validate_board_ai_roadmap
 else:
     from .manifest_utils import load_manifest_targets_from_dir, sha256_file
+    from .validate_board_ai_roadmap import validate as validate_board_ai_roadmap
 REQUIRED_REPORT_SECTION_IDS = {
     "scope",
     "obligations",
@@ -209,6 +211,10 @@ def run_validation(include_manifest: bool = True) -> dict:
     validate_control_catalog(controls)
     validate_roadmap(roadmap)
     validate_report_template(ARTIFACTS_DIR / "regulator-report-template.xml")
+    validate_board_ai_roadmap(
+        ARTIFACTS_DIR / "schemas" / "board-ai-roadmap-schema-v1.json",
+        ARTIFACTS_DIR / "data" / "board-ai-roadmap-2026-2030.json",
+    )
 
     checks = {
         "schema_documents": "pass",
@@ -216,6 +222,7 @@ def run_validation(include_manifest: bool = True) -> dict:
         "control_catalog": "pass",
         "roadmap": "pass",
         "report_template": "pass",
+        "board_ai_roadmap": "pass",
         "manifest": "skipped",
     }
 

--- a/artifacts/validate_board_ai_roadmap.py
+++ b/artifacts/validate_board_ai_roadmap.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate board AI roadmap artifact against JSON schema.
+
+Uses `jsonschema` when available. If unavailable, falls back to a minimal
+built-in validator that checks required structural constraints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_SCHEMA_PATH = ROOT / "schemas" / "board-ai-roadmap-schema-v1.json"
+DEFAULT_DATA_PATH = ROOT / "data" / "board-ai-roadmap-2026-2030.json"
+
+REQUIRED_TOP_LEVEL = {
+    "schema_version",
+    "program",
+    "financials",
+    "domains",
+    "jurisdictions",
+    "stage_gates",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate board AI roadmap artifact against schema."
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_SCHEMA_PATH,
+        help="Path to JSON schema file.",
+    )
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=DEFAULT_DATA_PATH,
+        help="Path to roadmap data JSON file.",
+    )
+    return parser.parse_args()
+
+
+def _fallback_validate(data: dict) -> None:
+    missing = REQUIRED_TOP_LEVEL - set(data)
+    if missing:
+        raise ValueError(f"missing required keys: {sorted(missing)}")
+
+    if data.get("schema_version") != "board-ai-roadmap-v1":
+        raise ValueError("schema_version must be board-ai-roadmap-v1")
+
+    period = data.get("program", {}).get("period")
+    if not isinstance(period, str) or not re.match(r"^\d{4}-\d{4}$", period):
+        raise ValueError("program.period must match YYYY-YYYY")
+
+    if not isinstance(data.get("domains"), list) or not data["domains"]:
+        raise ValueError("domains must be a non-empty array")
+
+    jurisdictions = data.get("jurisdictions")
+    for key in ("US", "EU", "UK", "APAC"):
+        if not isinstance(jurisdictions, dict) or key not in jurisdictions:
+            raise ValueError("jurisdictions must include US, EU, UK, APAC")
+
+    stage_gates = data.get("stage_gates")
+    if not isinstance(stage_gates, list) or not stage_gates:
+        raise ValueError("stage_gates must be a non-empty array")
+    for idx, gate in enumerate(stage_gates):
+        if not isinstance(gate, dict):
+            raise ValueError(f"stage_gates[{idx}] must be an object")
+        for field in ("gate", "target", "focus"):
+            if field not in gate:
+                raise ValueError(f"stage_gates[{idx}] missing field: {field}")
+        target = gate.get("target")
+        if not isinstance(target, str) or not re.match(r"^\d{4}-Q[1-4]$", target):
+            raise ValueError(f"stage_gates[{idx}].target must match YYYY-QN")
+
+
+def validate(schema_path: Path, data_path: Path) -> None:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    data = json.loads(data_path.read_text(encoding="utf-8"))
+
+    try:
+        import jsonschema  # type: ignore
+
+        jsonschema.validate(instance=data, schema=schema)
+    except ModuleNotFoundError:
+        _fallback_validate(data)
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        validate(args.schema, args.data)
+    except Exception as exc:  # pragma: no cover - CLI error path
+        print(f"Board AI roadmap artifact validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print("Board AI roadmap artifact validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/board_ai_transformation_roadmap_2026_2030.md
+++ b/board_ai_transformation_roadmap_2026_2030.md
@@ -1,0 +1,517 @@
+# Board Decision Briefing: AI Transformation Roadmap (2026-2030)
+
+## Context and Decision Request
+
+Approve a stage-gated AI transformation for 2026-2030 with:
+
+- Total investment: **$2.8B**.
+- Cumulative value target: **$4.2B**.
+- Risk-adjusted hurdle: **18% IRR**.
+- Capital release contingent on control and readiness gates.
+
+The board decision is not whether to "do AI." The decision is whether to fund
+an enterprise transformation with measurable value and explicit prudential
+controls.
+
+Machine-readable companion data is provided at
+`artifacts/data/board-ai-roadmap-2026-2030.json` with schema
+`artifacts/schemas/board-ai-roadmap-schema-v1.json` and validator
+`artifacts/validate_board_ai_roadmap.py`.
+
+## Executive Summary for Directors
+
+This roadmap is credible if control maturity leads deployment velocity. It
+should be run as a risk-adjusted portfolio with four linked outcomes:
+
+1. Revenue and franchise growth through better client experience.
+2. Structural productivity in operations and control functions.
+3. Stronger model, cyber, privacy, and operational resilience posture.
+4. Durable supervisory trust across major jurisdictions.
+
+Board recommendation: approve with quarterly stop/go gates and mandatory risk,
+compliance, and value evidence.
+
+## Board Decision Options (Today)
+
+- **Option A - Approve with conditions (recommended):** release Q1-Q2 2026
+  funding now; future tranches contingent on gate evidence.
+- **Option B - Partial approval:** fund only foundation and compliance work until
+  Q4 2026 evidence review.
+- **Option C - Defer:** postpone program start pending deeper data remediation.
+
+Recommended choice: **Option A** because delay increases competitive and
+operational drag, while stage gates preserve control over downside risk.
+
+## Requirement Coverage Matrix
+
+This briefing explicitly covers the board request scope:
+
+- Federated governance and three lines of defense.
+- Board-level oversight and decision options.
+- Regulatory compliance strategy: US, EU, UK, and APAC.
+- 2026-2030 phased milestones by year and quarter.
+- Domain roadmap: governance, infrastructure, risk, CX, operations, trading.
+- Financial case: investment, value, IRR hurdle, NPV, payback, downside.
+- Comprehensive risk framework: model, operational, cyber, privacy,
+  reputational, and resilience.
+- Workforce and culture plan for 50,000+ employees.
+- Strengths, gaps, execution risks, and success metrics.
+
+## Critical Evaluation
+
+### Strategic Strengths
+
+- Federated model balances global standards and local execution.
+- Three lines of defense (3LoD) are explicit and auditable.
+- Regulatory plan spans US, EU, UK, and APAC expectations.
+- Sequencing starts with low-risk productivity before high-risk trading use.
+
+### Material Gaps to Address Before Full Funding
+
+- Data lineage and remediation effort likely under-scoped.
+- Validation and compliance capacity may lag delivery demand.
+- Third-party concentration limits and exit plans are not yet hard-coded.
+- Benefit attribution must be CFO-owned to prevent double counting.
+
+### Primary Execution Risks
+
+- Pilot proliferation without production industrialization.
+- Local supervisory divergence creating deployment delays.
+- Control debt from faster release cadence than challenge capacity.
+- Underfunded people transition, reducing adoption and quality.
+
+## Federated Governance and Three Lines of Defense
+
+### Board and Management Governance
+
+- **Board Risk Committee:** risk appetite, threshold approval, escalations.
+- **Board Audit Committee:** independent control effectiveness assurance.
+- **Board Technology Committee:** portfolio decisions and dependencies.
+- **Group AI Council:** policy standards, taxonomy, control library ownership.
+- **Entity AI Committees:** local accountability and jurisdiction overlays.
+
+### Three Lines of Defense
+
+- **First line:** owns outcomes, model cards, testing evidence, monitoring, and
+  fallback runbooks.
+- **Second line:** owns policy, independent challenge, model tier approvals,
+  conduct controls, and regulatory interpretation.
+- **Third line:** performs thematic assurance and tests remediation closure
+  quality.
+
+### Quarterly Board Oversight Pack
+
+- Tier-1 model compliance rate.
+- Validation backlog and aging by risk tier.
+- High-severity incidents and detect/contain time.
+- Value realization versus plan by domain.
+- Control effectiveness score (design plus operating effectiveness).
+- Critical-skill vacancy and certification coverage.
+
+## Multi-Jurisdiction Compliance Strategy and Plans
+
+### United States (SR 11-7, OCC, CFPB)
+
+- Extend model lifecycle discipline to ML and GenAI classes.
+- Align third-party AI controls to OCC expectations.
+- Embed fair lending, adverse action, and UDAAP controls.
+
+Implementation plan:
+
+- **2026:** inventory, tiering, and policy harmonization.
+- **2027:** scaled explainability and adverse-action tooling.
+- **2028-2030:** automated evidence and continuous monitoring.
+
+### European Union (EU AI Act, GDPR, EBA)
+
+- Apply risk-based controls to high-risk systems from design stage.
+- Enforce GDPR lawful basis, minimization, DPIA, and transfer safeguards.
+- Align model and outsourcing governance to EBA expectations.
+
+Implementation plan:
+
+- **2026:** classification and control template library.
+- **2027:** conformity workflows in delivery lifecycle.
+- **2028-2030:** post-market monitoring and recertification.
+
+### United Kingdom (PRA, FCA, SM&CR, resilience)
+
+- Map material AI systems to named SM&CR accountability.
+- Tie AI dependencies to important business services.
+- Run severe-but-plausible AI disruption scenarios.
+
+Implementation plan:
+
+- **2026:** accountability mapping and governance codification.
+- **2027:** resilience scenario testing in annual cycle.
+- **2028-2030:** evidentiary packs and proactive engagement.
+
+### APAC (MAS FEAT, HKMA, cross-border data)
+
+- Implement FEAT-aligned fairness, accountability, and transparency controls.
+- Integrate HKMA governance with outsourcing and model controls.
+- Enforce jurisdiction-aware residency and transfer mechanisms.
+
+Implementation plan:
+
+- **2026-2027:** local overlays and residency controls.
+- **2028-2030:** federated testing and reusable evidence packs.
+
+### Cross-Jurisdiction Design Principle
+
+Operate one global control library with local overlays and one evidence model
+that can generate regulator-specific outputs.
+
+## Phased Milestones by Year and Quarter (Enterprise View)
+
+### 2026: Build Foundation
+
+- **Q1:** board appetite, policy suite, and stage-gate criteria approved.
+- **Q2:** enterprise model inventory and legal-entity ownership map complete.
+- **Q3:** control platform baseline (registry, lineage, monitoring, logging).
+- **Q4:** first low/medium-risk wave in operations and employee copilots.
+
+Dependencies: data remediation, cloud security architecture, IAM harmonization.
+
+### 2027: Controlled Scale
+
+- **Q1:** full 3LoD staffing and issue taxonomy standardization.
+- **Q2:** selected customer deployments with fairness controls.
+- **Q3:** resilience exercises for model and platform outages.
+- **Q4:** first cross-jurisdiction attestation cycle.
+
+Dependencies: incident automation, third-party controls, local pre-engagement.
+
+### 2028: Industrialization
+
+- **Q1:** portfolio rationalization and retirement discipline.
+- **Q2:** policy-as-code deployment for priority controls.
+- **Q3:** standardized drift, bias, and performance monitoring.
+- **Q4:** cross-border evidence federation live.
+
+Dependencies: metadata quality, control APIs, stable data contracts.
+
+### 2029: Core Value Chain Integration
+
+- **Q1:** straight-through processing expansion in operations.
+- **Q2:** controlled expansion to treasury and trading support.
+- **Q3:** compute and vendor cost optimization.
+- **Q4:** process redesign reflected in run-rate P&L.
+
+Dependencies: advanced model limits, HA failover, challenge capacity.
+
+### 2030: Maturity and Reset
+
+- **Q1:** fewer repeat findings and faster closure cycles.
+- **Q2:** AI embedded in priority customer and institutional journeys.
+- **Q3:** faster product innovation with controlled risk profile.
+- **Q4:** board strategy reset based on realized economics and risk outcomes.
+
+Dependencies: leadership continuity, talent refresh, supplier diversification.
+
+## Milestones by Domain (Governance to Trading)
+
+### Governance
+
+- 2026: policy baseline and entity accountabilities.
+- 2027: full 3LoD staffing and attestation.
+- 2028: policy-as-code and control automation.
+- 2029: dynamic risk-limit management.
+- 2030: mature assurance with low repeat findings.
+
+### Infrastructure
+
+- 2026: registry, lineage, and monitoring foundation.
+- 2027: resilient platform patterns in production.
+- 2028: cross-border evidence federation.
+- 2029: cost and performance optimization at scale.
+- 2030: modular architecture for next-cycle flexibility.
+
+### Risk and Controls
+
+- 2026: tiering, validation baseline, and incident taxonomy.
+- 2027: scaled challenge and resilience testing.
+- 2028: enterprise drift and bias automation.
+- 2029: advanced limits for high-impact domains.
+- 2030: continuous assurance and near-real-time reporting.
+
+### Customer Experience
+
+- 2026: limited-risk servicing copilots.
+- 2027: targeted journeys with fairness controls.
+- 2028: personalization under conduct guardrails.
+- 2029: broad rollout in priority journeys.
+- 2030: embedded AI experience with stable outcomes.
+
+### Operations
+
+- 2026: initial workflow automation.
+- 2027: expanded straight-through processing pilots.
+- 2028: standardized process redesign playbooks.
+- 2029: P&L-visible productivity at scale.
+- 2030: continuous improvement cycle.
+
+### Trading and Markets
+
+- 2026: sandbox use and policy framing.
+- 2027: controlled pilots with hard risk limits.
+- 2028: expanded decision support with oversight.
+- 2029: scaled usage in defined books.
+- 2030: mature model-risk limit discipline.
+
+## Financial Evaluation
+
+### Portfolio Economics
+
+**Assumption note:** cash flows are illustrative planning values for board
+scenario analysis, not formal guidance.
+
+- Investment (2026-2030): **$2.8B**.
+- Cumulative value: **$4.2B**.
+- Undiscounted net value: **$1.4B**.
+- Governance hurdle: **18% risk-adjusted IRR**.
+
+Illustrative net annual cash flows:
+
+- 2026: **-$0.80B**
+- 2027: **-$0.70B**
+- 2028: **+$0.50B**
+- 2029: **+$1.05B**
+- 2030: **+$1.35B**
+
+At a 10% discount rate, indicative NPV is about **+$0.63B**. Payback is about
+**4.2 years** (late 2029 to early 2030).
+
+### Use-Case ROI and Peer Benchmark View
+
+Expected higher and faster ROI clusters:
+
+- Operations automation and case management support.
+- Servicing productivity and contact-center augmentation.
+- Risk reporting and controls productivity.
+
+Expected higher upside but higher risk clusters:
+
+- Front-office advisory copilots.
+- Treasury and trading decision support.
+
+Peer G-SIB pattern to benchmark against:
+
+- Top quartile banks: early gains from operations and servicing first.
+- Median banks: value delayed by fragmented control architecture.
+- Lower quartile: pilot-heavy portfolio and weak industrialization.
+
+### Downside Sensitivity
+
+- 12-month realization delay with 20% lower benefits pushes payback past 2030.
+- Major control failures can trigger supervisory pauses and IRR compression.
+
+## Board RAG Assessment and Decision Conditions
+
+### Current Readiness View (for Approval Meeting)
+
+- **Strategy clarity:** Green.
+- **Governance design:** Amber (design strong, operating capacity scaling).
+- **Regulatory readiness:** Amber (jurisdiction execution depth still uneven).
+- **Data and infrastructure:** Amber (lineage and metadata remain bottlenecks).
+- **Value realization confidence:** Amber-Green (depends on industrialization pace).
+- **Workforce readiness:** Amber (control talent depth is tight).
+
+### Decision Conditions to Move from Amber to Green
+
+- Close >90% of tier-1 model documentation gaps by Q4 2026.
+- Achieve full tier-1 validation SLA compliance by Q2 2027.
+- Demonstrate cross-border evidence portability in at least three jurisdictions
+  by Q4 2028.
+- Keep unresolved high-severity findings at zero beyond 90 days.
+
+## Peer Benchmark Ranges for Board Calibration
+
+The following ranges are internal planning calibration bands for global-bank
+AI programs. They should be refreshed annually using Finance and Strategy
+benchmark packs before formal board approval cycles.
+
+- **Cost-to-income improvement from scaled AI programs:** 1.5-3.0 percentage
+  points over 4-5 years.
+- **Operations productivity uplift:** 12-25% in targeted workflows.
+- **Customer servicing cost reduction:** 10-20% in assisted channels.
+- **Model validation cycle-time improvement:** 20-40% after control automation.
+- **Critical incident reduction after control hardening:** 25-50% over two years.
+
+## Yearly Success Targets (Board Dashboard Expansion)
+
+### 2026 Targets
+
+- 100% inventory coverage for material AI systems.
+- 95% policy-control mapping completion for tier-1 systems.
+- 0 unresolved critical findings older than 90 days.
+
+### 2027 Targets
+
+- 100% validation coverage for tier-1 production systems.
+- <30 days median closure for high-priority control findings.
+- >=15% realized benefit against 2030 cumulative value target.
+
+### 2028 Targets
+
+- 100% cross-jurisdiction attestation for in-scope entities.
+- >=70% automated monitoring coverage for tier-1/2 systems.
+- >=45% cumulative value realization versus full-program target.
+
+### 2029 Targets
+
+- >=85% enterprise adoption in prioritized operating workflows.
+- >=80% of value from scaled, repeatable processes (not pilots).
+- <=5% critical role vacancy in AI control functions.
+
+### 2030 Targets
+
+- >=100% of planned cumulative value realization with controlled risk profile.
+- Stable supervisory outcomes with no material repeat findings themes.
+- Board-approved next-cycle strategy with refreshed risk appetite.
+
+## Stage-Gate Funding Criteria (Board Controls)
+
+### Gate 1: Foundation Readiness (Target: Q2 2026)
+
+Must-have evidence:
+
+- Complete inventory of material AI systems.
+- Risk tiering taxonomy and accountable executive map.
+- Baseline control library and policy publication.
+
+### Gate 2: Controlled Customer Deployment (Target: Q2 2027)
+
+Must-have evidence:
+
+- Tier-1 validation coverage at 100% for in-scope launches.
+- Fairness and explainability controls operating in production.
+- Incident runbooks tested with time-to-contain metrics.
+
+### Gate 3: Industrialized Compliance (Target: Q4 2028)
+
+Must-have evidence:
+
+- Cross-jurisdiction attestation completed on schedule.
+- Policy-as-code controls enforced for critical pathways.
+- Drift, bias, and performance monitoring with escalation thresholds.
+
+### Gate 4: High-Impact Scale (Target: Q4 2029)
+
+Must-have evidence:
+
+- Risk limits and oversight proven for trading/treasury support.
+- Resilience tests passed for critical-service disruption scenarios.
+- Value realization on-track versus board-approved baseline.
+
+## Enterprise AI Risk Management Framework
+
+### Risk Domains
+
+1. Model risk.
+2. Operational risk.
+3. Cyber risk.
+4. Privacy and cross-border data risk.
+5. Reputational and conduct risk.
+6. Operational resilience and concentration risk.
+
+### Lifecycle Controls
+
+- **Design:** classification, data suitability, control mapping.
+- **Build:** secure engineering and documentation completeness.
+- **Validate:** independent challenge, robustness, fairness, explainability.
+- **Deploy:** gate approvals, rollback design, release controls.
+- **Run:** continuous monitoring, anomaly management, incident response.
+- **Retire:** decommission controls and evidence retention obligations.
+
+### Board Risk Thresholds
+
+- Zero unresolved high-severity findings older than 90 days.
+- 100% validation coverage for tier-1 material models.
+- Immediate board escalation for severe customer-harm or service outage.
+
+## Workforce, Culture, and Change for 50,000+ Employees
+
+### Workforce Segmentation
+
+1. AI builders.
+2. AI control professionals.
+3. AI-enabled operators.
+4. Leadership cohort.
+
+### Training and Reskilling
+
+- Mandatory enterprise AI literacy baseline.
+- Role-based accreditation for material AI roles.
+- Specialist academies in model risk, privacy engineering, AI security.
+- Manager enablement for AI-human work redesign.
+
+### Culture and Incentive Model
+
+- Incentives linked to both value delivery and control quality.
+- No-fault escalation norms to surface issues early.
+- Transparent role-transition pathways to reduce friction and attrition.
+
+### People Metrics
+
+- >90% literacy completion by end-2028.
+- 100% accreditation in material AI roles.
+- <8% critical-role vacancy rate by 2029.
+- Adoption and productivity metrics tied to realized outcomes.
+
+## Board Dashboard and Success Metrics
+
+Track five metric groups each quarter:
+
+- Financial: net value, payback trajectory, run-rate realization.
+- Risk/control: incident severity, backlog aging, control pass rates.
+- Compliance: attestation coverage and closure cycle times.
+- Resilience: disruption test pass rate for critical services.
+- People: certification, retention, adoption depth.
+
+## Appendix A: Implementation Ownership Model (RACI)
+
+### Governance and Controls
+
+- **Responsible:** Group AI Council, entity AI committees, first-line owners.
+- **Accountable:** Group Chief Risk Officer and designated legal-entity execs.
+- **Consulted:** Compliance, legal, privacy, cyber, model risk, internal audit.
+- **Informed:** Board Risk, Board Audit, and Board Technology committees.
+
+### Platform and Data
+
+- **Responsible:** CIO, data platform engineering, model platform engineering.
+- **Accountable:** Group CIO and chief data officer.
+- **Consulted:** Security architecture, privacy office, operational resilience.
+- **Informed:** Business-line AI offices and control functions.
+
+### Business Value Realization
+
+- **Responsible:** Business-line AI offices and process owners.
+- **Accountable:** Business CEOs and Group CFO for benefit sign-off.
+- **Consulted:** Transformation office and finance analytics.
+- **Informed:** Board committees and internal audit.
+
+## Appendix B: KPI Definition Notes
+
+- **Value realization:** finance-approved realized benefit net of run costs.
+- **Tier-1 validation coverage:** percent of tier-1 production models with
+  completed independent validation within approved cycle.
+- **High-severity incident:** event with potential material customer harm,
+  regulatory breach, or critical-service impact.
+- **Attestation coverage:** percent of in-scope legal entities completing
+  required jurisdictional control attestations on schedule.
+- **Adoption depth:** percent of target workflows meeting usage and quality
+  thresholds for at least two consecutive quarters.
+
+## Final Recommendation
+
+Proceed with the 2026-2030 roadmap under strict conditionality:
+
+1. Quarterly stage-gated capital release.
+2. Hard control prerequisites for tier-1 deployments.
+3. Regulator-readiness evidence before major launches.
+4. Downside triggers for portfolio reallocation.
+
+This is the strongest risk-adjusted path to achieve target economics while
+meeting prudential, conduct, and resilience expectations for a global G-SIB.

--- a/unit_tests/test_artifacts_validation.py
+++ b/unit_tests/test_artifacts_validation.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import sys
+from pathlib import Path
 from argparse import Namespace
 
 import pytest
@@ -28,6 +29,40 @@ def run_python(*args: str) -> subprocess.CompletedProcess[str]:
         check=False,
     )
 
+
+def test_board_roadmap_validator_cli_runs():
+    proc = run_python("artifacts/validate_board_ai_roadmap.py")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "validation passed" in proc.stdout.lower()
+
+
+def test_board_roadmap_validator_cli_fails_on_missing_schema_file():
+    proc = run_python(
+        "artifacts/validate_board_ai_roadmap.py",
+        "--schema",
+        "artifacts/schemas/does-not-exist.json",
+    )
+    assert proc.returncode == 1
+    assert "validation failed" in proc.stderr.lower()
+
+def test_board_roadmap_validator_cli_fails_on_missing_file():
+    proc = run_python(
+        "artifacts/validate_board_ai_roadmap.py",
+        "--data",
+        "artifacts/data/does-not-exist.json",
+    )
+    assert proc.returncode == 1
+    assert "validation failed" in proc.stderr.lower()
+
+def test_board_roadmap_validator_cli_fails_on_invalid_data(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text('{"schema_version": "board-ai-roadmap-v1"}', encoding="utf-8")
+    proc = run_python(
+        "artifacts/validate_board_ai_roadmap.py",
+        "--data",
+        str(bad),
+    )
+    assert proc.returncode != 0
 
 def test_artifacts_validation_script_runs():
     proc = run_python("artifacts/validate_artifacts.py")
@@ -103,6 +138,19 @@ def test_display_artifact_path_preserves_non_artifact_paths(monkeypatch, tmp_pat
     monkeypatch.setattr(validate_artifacts, "ARTIFACTS_DIR", artifact_dir)
     assert display_artifact_path(external) == str(external)
 
+
+def test_validation_json_output_includes_board_ai_roadmap_check():
+    proc = run_python("artifacts/validate_artifacts.py", "--json")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["checks"]["board_ai_roadmap"] == "pass"
+
+
+def test_manifest_targets_contains_board_ai_roadmap_files():
+    targets = load_manifest_targets()
+    assert "data/board-ai-roadmap-2026-2030.json" in targets
+    assert "schemas/board-ai-roadmap-schema-v1.json" in targets
+    assert "validate_board_ai_roadmap.py" in targets
 
 def test_manifest_targets_contains_expected_blueprint_file():
     targets = load_manifest_targets()
@@ -306,6 +354,7 @@ def test_check_all_json_mode():
     assert payload["validation_ok"] is True
     assert payload["errors"] == []
     assert payload["checked_at"].endswith("+00:00")
+    assert payload["validation_checks"]["board_ai_roadmap"] == "pass"
 
 
 def test_check_all_detects_manifest_staleness(monkeypatch):
@@ -444,3 +493,9 @@ def test_manifest_coverage_detects_extra_file(tmp_path):
     }
     with pytest.raises(ValidationError, match="coverage mismatch"):
         validate_manifest(tmp_path, manifest)
+
+
+def test_artifacts_makefile_test_target_includes_board_roadmap_tests():
+    makefile = Path("artifacts/Makefile").read_text(encoding="utf-8")
+    assert "unit_tests/test_artifacts_validation.py" in makefile
+    assert "unit_tests/test_validate_board_ai_roadmap.py" in makefile

--- a/unit_tests/test_validate_board_ai_roadmap.py
+++ b/unit_tests/test_validate_board_ai_roadmap.py
@@ -1,0 +1,81 @@
+import builtins
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from artifacts.validate_board_ai_roadmap import (
+    DEFAULT_DATA_PATH,
+    DEFAULT_SCHEMA_PATH,
+    validate,
+)
+
+try:
+    from jsonschema import ValidationError as JsonSchemaValidationError
+
+    EXPECTED_ERRORS = (JsonSchemaValidationError, ValueError)
+except Exception:  # pragma: no cover - jsonschema may be absent by design
+    EXPECTED_ERRORS = (ValueError,)
+
+
+def test_default_files_validate() -> None:
+    validate(DEFAULT_SCHEMA_PATH, DEFAULT_DATA_PATH)
+
+
+def test_invalid_data_fails_validation() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        bad_data = tmp / "bad.json"
+        payload = json.loads(DEFAULT_DATA_PATH.read_text(encoding="utf-8"))
+        payload.pop("schema_version", None)
+        bad_data.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(EXPECTED_ERRORS):
+            validate(DEFAULT_SCHEMA_PATH, bad_data)
+
+
+def test_invalid_stage_gate_target_fails_validation() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        bad_data = tmp / "bad-target.json"
+        payload = json.loads(DEFAULT_DATA_PATH.read_text(encoding="utf-8"))
+        payload["stage_gates"][0]["target"] = "2026-Q9"
+        bad_data.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(EXPECTED_ERRORS):
+            validate(DEFAULT_SCHEMA_PATH, bad_data)
+
+
+def test_invalid_program_period_fails_validation() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        bad_data = tmp / "bad-period.json"
+        payload = json.loads(DEFAULT_DATA_PATH.read_text(encoding="utf-8"))
+        payload["program"]["period"] = "2026/2030"
+        bad_data.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(EXPECTED_ERRORS):
+            validate(DEFAULT_SCHEMA_PATH, bad_data)
+
+
+
+def test_fallback_validation_path_without_jsonschema(monkeypatch) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "jsonschema":
+            raise ModuleNotFoundError("jsonschema")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        bad_data = tmp / "bad-fallback.json"
+        payload = json.loads(DEFAULT_DATA_PATH.read_text(encoding="utf-8"))
+        payload["program"]["period"] = "bad-period"
+        bad_data.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(ValueError):
+            validate(DEFAULT_SCHEMA_PATH, bad_data)


### PR DESCRIPTION
### Motivation

- Add a machine-readable board AI transformation roadmap and ensure it is schema-validated as part of the artifacts validation workflow. 
- Integrate roadmap validation into existing artifact checks and CI to keep the manifest and coverage consistent.

### Description

- Add the board roadmap data at `artifacts/data/board-ai-roadmap-2026-2030.json` and a formal JSON Schema at `artifacts/schemas/board-ai-roadmap-schema-v1.json`.
- Add a schema validator `artifacts/validate_board_ai_roadmap.py` that uses `jsonschema` when available and falls back to a lightweight built-in checker otherwise, and wire it into `artifacts/validate_artifacts.py` so the roadmap is validated with other artifacts.
- Update manifest targets (`artifacts/manifest-targets-v1.json`) and checksum manifest (`artifacts/artifact-manifest-v1.json`) to include the new files and refresh the `generated_at` timestamp, and add `jsonschema` to `artifacts/requirements-artifacts.txt`.
- Add the human-facing briefing `board_ai_transformation_roadmap_2026_2030.md`, update `artifacts/README.md` and `artifacts/Makefile` to include the new validator and test targets, and extend unit tests (`unit_tests/test_validate_board_ai_roadmap.py`) and existing validation tests to cover the new checks.

### Testing

- Ran `pytest -q unit_tests/test_artifacts_validation.py unit_tests/test_validate_board_ai_roadmap.py` and all tests passed.
- Exercised the CLI paths for `artifacts/validate_board_ai_roadmap.py` and `artifacts/validate_artifacts.py --json` via unit tests which asserted success and expected failure modes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1316e4948329a52c3fb70f05290e)

## Summary by Sourcery

Add a schema-validated board AI roadmap artifact and integrate its validation into the existing artifacts workflow and CI.

New Features:
- Introduce a machine-readable board AI transformation roadmap JSON artifact and corresponding JSON Schema for 2026-2030.
- Add a dedicated CLI validator for the board AI roadmap artifact and wire it into the aggregated artifacts validation flow.
- Provide a board-facing AI transformation roadmap briefing document aligned with the new machine-readable artifact.

Enhancements:
- Extend artifacts validation JSON output and check-all reporting to include the board AI roadmap check status.
- Update artifact manifests, manifest targets, and Makefile targets to track and validate the new roadmap files.
- Document the new roadmap artifact, schema, and validator usage in the artifacts README, including updated testing guidance.

Build:
- Add jsonschema as an optional dependency for artifact validation via the artifacts requirements file.

Tests:
- Add targeted unit tests for the board AI roadmap validator, including fallback behavior when jsonschema is unavailable.
- Expand existing artifact validation tests to cover the new roadmap checks, manifest coverage, and Makefile test wiring.
- Ensure CLI-level tests assert success and expected failure modes for the roadmap validator and overall artifacts validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added board AI transformation roadmap artifact with investment targets, financial metrics, and staged gate milestones.
  * Added validation capability for board AI roadmap data.

* **Documentation**
  * Added board briefing document outlining AI transformation roadmap (2026–2030) with governance, compliance, and implementation strategy.
  * Updated artifact documentation with roadmap governance details.

* **Tests**
  * Expanded validation test suite for new roadmap artifact.

* **Chores**
  * Added jsonschema dependency.
  * Updated artifact manifest with new roadmap entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->