### PR TITLE
Add modular federated-zk compliance docs, link validator, tests, and CI workflow

### DIFF
--- a/.github/workflows/federated-zk-docs-validation.yml
+++ b/.github/workflows/federated-zk-docs-validation.yml
@@ -1,0 +1,33 @@
+name: Federated ZK Docs Validation
+
+on:
+  push:
+    paths:
+      - 'FEDERATED_ZK_AI_COMPLIANCE_RESEARCH_PROGRAM_SYNTHESIS.md'
+      - 'docs/federated-zk-compliance/**'
+      - 'tests/test_federated_zk_validate_docs.py'
+      - '.github/workflows/federated-zk-docs-validation.yml'
+  pull_request:
+    paths:
+      - 'FEDERATED_ZK_AI_COMPLIANCE_RESEARCH_PROGRAM_SYNTHESIS.md'
+      - 'docs/federated-zk-compliance/**'
+      - 'tests/test_federated_zk_validate_docs.py'
+      - '.github/workflows/federated-zk-docs-validation.yml'
+
+jobs:
+  validate-doc-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run validator unit tests
+        run: python -m unittest discover -s tests -p 'test_federated_zk_validate_docs.py'
+
+      - name: Validate federated-zk doc links (strict)
+        run: python docs/federated-zk-compliance/validate_docs.py --strict

--- a/FEDERATED_ZK_AI_COMPLIANCE_RESEARCH_PROGRAM_SYNTHESIS.md
+++ b/FEDERATED_ZK_AI_COMPLIANCE_RESEARCH_PROGRAM_SYNTHESIS.md
@@ -24,4 +24,3 @@ The prior single-file draft became too large for review workflows. The content h
 
 - Prior monolithic draft: v0.4
 - Current modular package baseline: v0.5
-

--- a/FEDERATED_ZK_AI_COMPLIANCE_RESEARCH_PROGRAM_SYNTHESIS.md
+++ b/FEDERATED_ZK_AI_COMPLIANCE_RESEARCH_PROGRAM_SYNTHESIS.md
@@ -1,0 +1,27 @@
+# Federated ZK AI Compliance Research Program Synthesis
+
+This document is now the **navigation entrypoint** for the modularized synthesis package.
+
+## Why modularized
+
+The prior single-file draft became too large for review workflows. The content has been reorganized into focused documents to support:
+- easier regulator/legal review,
+- clearer ownership by workstream,
+- cleaner change-tracking over time.
+
+## Document map
+
+- `docs/federated-zk-compliance/_index.md` — package index and recommended review path.
+- `docs/federated-zk-compliance/full_synthesis_v0.5.md` — complete integrated synthesis (legacy single-file equivalent).
+- `docs/federated-zk-compliance/01_architecture_stack.md` — layered architecture and formal model.
+- `docs/federated-zk-compliance/02_enterprise_governance.md` — containment and constitutional controls.
+- `docs/federated-zk-compliance/03_crypto_and_federation.md` — zk pipeline and verifier federation.
+- `docs/federated-zk-compliance/04_infrastructure_and_regulation.md` — Terraform/Kubernetes and EU supervisory mapping.
+- `docs/federated-zk-compliance/05_treaty_recoverability_rollout.md` — GACP, recoverability metrics, rollout playbooks.
+- `docs/federated-zk-compliance/06_annexes.md` — artifact templates, glossary, and traceability matrix.
+
+## Versioning
+
+- Prior monolithic draft: v0.4
+- Current modular package baseline: v0.5
+

--- a/docs/federated-zk-compliance/01_architecture_stack.md
+++ b/docs/federated-zk-compliance/01_architecture_stack.md
@@ -1,0 +1,31 @@
+# 01 — Layered Architecture and Formal Model
+
+## Purpose
+Define the canonical L0–L9 stack and the formal semantics used by all downstream governance, infrastructure, and supervisory artifacts.
+
+## L0–L9 Architecture
+- **L0 Ontology/Epistemics**: claim types, evidentiary semantics, uncertainty operators.
+- **L1 Formal Semantics**: state-transition admissibility and proof obligations.
+- **L2 Cryptographic Fabric**: commitments, zk circuits, recursive aggregation.
+- **L3 Runtime Substrate**: deterministic telemetry and reproducible execution environments.
+- **L4 Enterprise Governance**: constitutional policy and containment controls.
+- **L5 Regulatory Mapping**: control-to-obligation alignment (EU AI Act, Basel, DORA).
+- **L6 Jurisprudential Layer**: admissibility, appeals, and precedent mapping.
+- **L7 Federation Layer**: verifier membership, quorum governance, dispute protocol.
+- **L8 Recoverability Layer**: continuity metrics and reconstruction workflows.
+- **L9 Frontier Layer**: bounded theoretical hypotheses requiring falsifiability.
+
+## Minimal Formal Semantics
+Let `S` = states, `A` = actions, `T` = transitions, `C` = controls, `R` = reporting windows.
+- Admissibility predicate: `P: S × A -> {0,1}`.
+- Evidence map: `E: T -> H` where `H` is hash-linked evidence history.
+- Compliance satisfaction `Sat(i,j,c,r)=1` iff verifier `j` accepts proof for statement `stmt(i,c,r)` with required evidence commitments.
+
+## Deterministic Supervisory Equivalence (DSE)
+For shared controls across jurisdictions, DSE is satisfied when harmonized predicates yield equivalent supervisory outcomes under agreed assumptions.
+
+## Outputs of this workstream
+1. Versioned architecture map.
+2. Predicate dictionary.
+3. Cross-layer dependency table.
+4. DSE harmonization profile template.

--- a/docs/federated-zk-compliance/02_enterprise_governance.md
+++ b/docs/federated-zk-compliance/02_enterprise_governance.md
@@ -1,0 +1,27 @@
+# 02 — Enterprise AGI/ASI Governance and Containment
+
+## Purpose
+Specify enterprise controls for high-capability AI systems with constitutional constraints, deterministic auditing, and recoverable fail-safe pathways.
+
+## Constitutional Control Hierarchy
+1. **Foundational invariants**: non-overridable constraints (e.g., human override domains).
+2. **Statutory controls**: jurisdiction and sector obligations.
+3. **Operational directives**: deployment-time rules bounded by higher invariants.
+
+## Control Plane Design
+- Signed policy bundles and versioned lineage.
+- Immutable evidence logging for privileged actions.
+- Segmented execution zones (training/eval/deploy/actuation).
+- Preventive and detective controls with automatic quarantine policies.
+
+## TLA+ Property Families
+- **Safety**: no unauthorized external actuation.
+- **Liveness**: all fault states converge to safe fallback.
+- **Auditability**: all privileged actions produce verifiable evidence.
+- **Rollback integrity**: policy rollback cannot bypass required controls.
+
+## Pilot Readiness Artifacts
+1. Policy-kernel specification.
+2. TLA+ property pack and model-check results.
+3. Runtime-control test protocol.
+4. Incident escalation and replay runbook.

--- a/docs/federated-zk-compliance/03_crypto_and_federation.md
+++ b/docs/federated-zk-compliance/03_crypto_and_federation.md
@@ -1,0 +1,30 @@
+# 03 — zk Proof Pipeline and Verifier Federation
+
+## Purpose
+Define the cryptographic compliance lifecycle from evidence generation through supervisory verification, including federation governance.
+
+## Proof Pipeline
+1. Canonicalize and sign evidence events.
+2. Build commitments for reporting windows.
+3. Execute zk circuits for mapped controls.
+4. Aggregate proofs recursively for submission efficiency.
+5. Verify against jurisdiction policy profiles.
+6. Publish evidence envelope and verifier receipts.
+
+## Security Requirements
+- Completeness and soundness.
+- Non-malleability of supervisory submissions.
+- Domain separation across institutions and jurisdictions.
+- Key-rotation continuity and forward security.
+
+## Verifier Federation Model
+- Roles: national supervisor, regional supervisor, multilateral observer.
+- Governance: threshold validation `(n,t)` and quorum publication.
+- Challenge-response: time-bounded dispute procedures with evidence replay.
+- Membership discipline: accession, suspension, reinstatement.
+
+## Required Artifacts
+1. Assumption register.
+2. Proof-system profile matrix.
+3. Federation policy configuration.
+4. Challenge-response SOP.

--- a/docs/federated-zk-compliance/04_infrastructure_and_regulation.md
+++ b/docs/federated-zk-compliance/04_infrastructure_and_regulation.md
@@ -1,0 +1,26 @@
+# 04 — Infrastructure and Regulatory Mapping
+
+## Purpose
+Provide deployable infrastructure patterns and regulatory crosswalks for supervisory-grade AI compliance operations.
+
+## Infrastructure Blueprint
+- Terraform modules for identity/KMS, regional GPU compute, evidence stream, and verifier gateway.
+- Kubernetes controls for signed image admission, policy sidecars, immutable audit exporters, and quarantine namespaces.
+- Regional partitioning and sovereign key custody for jurisdictional compliance.
+
+## Regulatory Mapping
+- **EU AI Act**: risk management, traceability, incident/post-market obligations.
+- **Basel alignment**: model risk governance evidence and maturity indicators.
+- **DORA alignment**: resilience controls and continuity stress evidence.
+
+## Regulator Submission Dossier
+1. Control crosswalk matrix.
+2. Proof summary and assumption register.
+3. Exception ledger + compensating controls.
+4. Continuity/resilience package.
+5. Independent attestation memo.
+
+## Deliverables
+- Reference Terraform interface contracts.
+- Kubernetes policy baseline.
+- Regulator submission template pack.

--- a/docs/federated-zk-compliance/05_treaty_recoverability_rollout.md
+++ b/docs/federated-zk-compliance/05_treaty_recoverability_rollout.md
@@ -1,0 +1,28 @@
+# 05 — Treaty Layer, Recoverability, and Rollout
+
+## Purpose
+Define multilateral governance lifecycle, continuity metrics, and phased deployment strategy.
+
+## GACP Lifecycle
+- **Accession**: capability declaration and conformance trial.
+- **Conditional membership**: bounded production participation.
+- **Full membership**: reciprocal equivalence rights.
+- **Suspension/Reinstatement**: treaty-triggered, evidence-based procedures.
+
+## Recoverability Metric Pack
+- `RL`: reconstruction latency.
+- `CIS`: continuity integrity score.
+- `PSR`: proof survivability ratio.
+- `CPI`: constitutional preservation index.
+
+## Rollout Phases (0–36 months)
+- Phase 0: standards and ontology harmonization.
+- Phase 1: bilateral regulator sandboxes.
+- Phase 2: regional federation interoperability.
+- Phase 3: multilateral accession and treaty pilots.
+
+## Phase Exit Criteria
+- Verified control conformance.
+- Demonstrated resilience drills.
+- Accepted supervisory dossier outcomes.
+- Documented dispute-resolution performance.

--- a/docs/federated-zk-compliance/06_annexes.md
+++ b/docs/federated-zk-compliance/06_annexes.md
@@ -1,0 +1,24 @@
+# 06 — Annexes
+
+## Purpose
+Provide concrete starter templates and shared vocabulary for execution.
+
+## Annex Inventory
+1. TLA+ property checklist.
+2. OSCAL starter control mappings.
+3. zk proof submission envelope skeleton.
+4. Terraform/Kubernetes reference control contracts.
+5. Supervisory dossier template.
+6. KPI scorecard.
+7. Glossary of core terms.
+8. Requirement-to-artifact traceability matrix.
+
+## Usage Guidance
+- Treat annexes as baseline patterns, not exhaustive standards.
+- Version all templates with explicit assumption and jurisdiction tags.
+- Require independent review before adoption in supervisory production flows.
+
+## Governance of Annexes
+- Update cadence: quarterly or on major legal/crypto change.
+- Review owners: legal, supervisory engineering, security assurance.
+- Approval gate: federation council + independent assessor concurrence.

--- a/docs/federated-zk-compliance/CHANGELOG.md
+++ b/docs/federated-zk-compliance/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog — Federated ZK Compliance Docs
+
+## v0.5 (current)
+- Introduced modular package structure and navigation entrypoint.
+- Added focused workstream modules (`01`–`06`).
+- Added integrated full synthesis reference.
+- Added package README and versioning guidance.
+
+## Change control rules
+- Increment **patch** for editorial clarifications.
+- Increment **minor** for new module sections, templates, or governance artifacts.
+- Increment **major** for taxonomy changes (e.g., architecture layers, formal predicate semantics, or treaty lifecycle model changes).

--- a/docs/federated-zk-compliance/README.md
+++ b/docs/federated-zk-compliance/README.md
@@ -1,0 +1,23 @@
+# Federated ZK Compliance Documentation Package (v0.5)
+
+## Overview
+This directory contains the modularized federated zk AI compliance synthesis package.
+
+## Files
+- `full_synthesis_v0.5.md` — full integrated reference.
+- `01_architecture_stack.md` — architecture and formal semantics.
+- `02_enterprise_governance.md` — enterprise containment/governance controls.
+- `03_crypto_and_federation.md` — zk pipeline and verifier federation.
+- `04_infrastructure_and_regulation.md` — infra and regulatory mapping.
+- `05_treaty_recoverability_rollout.md` — treaty lifecycle and rollout strategy.
+- `06_annexes.md` — annex inventory and governance.
+
+## Change management
+- Baseline version: `v0.5`
+- Update policy: maintain module-level updates with synchronized version notes in the top-level navigation file.
+
+## Contribution workflow
+1. Edit the smallest relevant module first (`01`–`06`).
+2. If needed, mirror substantial updates into `full_synthesis_v0.5.md`.
+3. Update `CHANGELOG.md` with version-impact notes.
+4. Keep version labels synchronized across this README, top-level navigation, and full synthesis metadata.

--- a/docs/federated-zk-compliance/_index.md
+++ b/docs/federated-zk-compliance/_index.md
@@ -1,0 +1,20 @@
+# Federated ZK Compliance Package Index
+
+## Quick navigation
+- [README](README.md)
+- [CHANGELOG](CHANGELOG.md)
+- [Full synthesis v0.5](full_synthesis_v0.5.md)
+
+## Workstream modules
+1. [01 — Layered Architecture and Formal Model](01_architecture_stack.md)
+2. [02 — Enterprise AGI/ASI Governance and Containment](02_enterprise_governance.md)
+3. [03 — zk Proof Pipeline and Verifier Federation](03_crypto_and_federation.md)
+4. [04 — Infrastructure and Regulatory Mapping](04_infrastructure_and_regulation.md)
+5. [05 — Treaty Layer, Recoverability, and Rollout](05_treaty_recoverability_rollout.md)
+6. [06 — Annexes](06_annexes.md)
+
+## Review path (recommended)
+1. `README.md` (scope/versioning)
+2. `01` → `05` (core technical/governance flow)
+3. `06_annexes.md` (templates)
+4. `full_synthesis_v0.5.md` (integrated reference)

--- a/docs/federated-zk-compliance/full_synthesis_v0.5.md
+++ b/docs/federated-zk-compliance/full_synthesis_v0.5.md
@@ -1,0 +1,469 @@
+# Federated Zero-Knowledge AI Compliance, Supervisory Governance, and Recoverability-Resonance Constitutional Frameworks
+
+**Document status:** Draft v0.5  
+**Intended audience:** Regulators, supervisory technologists, enterprise governance teams, policy/legal architects  
+**Usage:** Research-to-pilot reference blueprint (non-binding)
+
+
+## Companion Modules
+
+This integrated reference is paired with modular workstream documents:
+- `01_architecture_stack.md`
+- `02_enterprise_governance.md`
+- `03_crypto_and_federation.md`
+- `04_infrastructure_and_regulation.md`
+- `05_treaty_recoverability_rollout.md`
+- `06_annexes.md`
+
+## Table of Contents
+- [Abstract](#abstract)
+- [Scope, Assumptions, and Non-Goals](#scope-assumptions-and-non-goals)
+- [1) Layered Research and Architecture Stack (L0-L9)](#1-layered-research-and-architecture-stack-l0-l9)
+- [2) Enterprise AGI/ASI Containment and Governance Stack](#2-enterprise-agiasi-containment-and-governance-stack)
+- [3) Formalization and Reference Predicates](#3-formalization-and-reference-predicates)
+- [4) zk Proof Pipeline and Verifier Federation Protocol](#4-zk-proof-pipeline-and-verifier-federation-protocol)
+- [5) Infrastructure Blueprint (Terraform + Multi-Region GPU + Kubernetes)](#5-infrastructure-blueprint-terraform--multi-region-gpu--kubernetes)
+- [6) Regulatory Mapping for EU Financial Supervision](#6-regulatory-mapping-for-eu-financial-supervision)
+- [7) Treaty and Legal Recognition Architecture](#7-treaty-and-legal-recognition-architecture)
+- [8) Recoverability, Continuity, and Near-Criticality Governance](#8-recoverability-continuity-and-near-criticality-governance)
+- [9) Pilot Playbooks and Rollout Strategy](#9-pilot-playbooks-and-rollout-strategy)
+- [10) Governance Operating Model and Accountability](#10-governance-operating-model-and-accountability)
+- [11) Critical Analysis: Main Risks and Failure Modes](#11-critical-analysis-main-risks-and-failure-modes)
+- [12) Open Research Problems](#12-open-research-problems)
+- [13) Minimal Deliverables for First National Pilot](#13-minimal-deliverables-for-first-national-pilot)
+- [14) Conclusion](#14-conclusion)
+- [Annexes A-D](#annex-a-concrete-artifact-blueprints-implementation-starters)
+
+
+## Abstract
+
+This artifact proposes an integrated research and deployment program for federated zero-knowledge (zk) AI compliance across enterprise, regulatory, and multilateral layers. The objective is to make supervision **deterministic, privacy-preserving, interoperable, and recoverable** by combining formal methods, cryptographic proofs, treaty-aligned governance, and continuity engineering.
+
+## Scope, Assumptions, and Non-Goals
+
+### Scope
+- Enterprise AGI/ASI containment and governance controls.
+- zk-based compliance evidence generation and verification.
+- EU financial-sector supervisory mappings (EU AI Act, Basel, DORA).
+- National/regional/global verifier federation and legal recognition workflows.
+- Recoverability/continuity design for high-criticality adaptive systems.
+
+### Assumptions
+- Participating institutions can produce signed, immutable evidence events.
+- Regulators can consume machine-verifiable evidence bundles.
+- Jurisdictions accept negotiated harmonization profiles for shared controls.
+- Threat models and crypto assumptions are versioned and publicly auditable.
+
+### Non-Goals
+- Not a substitute for statute or case law.
+- Not a claim that zk proofs alone solve semantic/legal disagreement.
+- Not a production-ready reference implementation.
+
+---
+
+## 1) Layered Research and Architecture Stack (L0-L9)
+
+- **L0 Ontology/Epistemics**: evidence types, claim semantics, uncertainty operators.
+- **L1 Formal Semantics**: system states, admissible transitions, proof obligations.
+- **L2 Cryptographic Fabric**: commitments, zk circuits, recursion, verifier APIs.
+- **L3 Runtime Substrate**: Terraform, Kubernetes, confidential compute, telemetry.
+- **L4 Enterprise Governance**: constitutional policy kernel, containment controls.
+- **L5 Regulatory Mapping**: EU AI Act/Basel/DORA obligations to formal predicates.
+- **L6 Jurisprudential Layer**: legal validity, appeals, amendment and precedent logic.
+- **L7 Federation Layer**: cross-jurisdiction verifiers, accession and revocation.
+- **L8 Recoverability Science**: continuity metrics, replay, resilience near criticality.
+- **L9 Frontier Theory**: epistemic/resonance hypotheses with falsifiability criteria.
+
+Design thesis: governance quality is a function of the **fidelity, composability, and recoverability** of supervisory evidence.
+
+---
+
+## 2) Enterprise AGI/ASI Containment and Governance Stack
+
+### 2.1 Constitutional Control Model
+
+1. **Foundational invariants** (immutable): human override domains, prohibited outcomes.
+2. **Statutory controls** (versioned): sector/jurisdiction obligations.
+3. **Operational directives** (fast-changing): deployment-specific policy updates.
+
+All layers are linked via signed policy lineage and machine-checkable compatibility constraints.
+
+### 2.2 Control-Plane Components
+
+- Constitutional policy kernel.
+- Deterministic governance plane (signed artifacts + immutable logs).
+- Assurance-by-construction runtime segmentation.
+- Preventive + detective safety channels.
+- Emergency kill-switch and safe-fallback replay mechanisms.
+
+### 2.3 TLA+ Property Classes
+
+- **Safety**: disallow external actuation unless authorization quorum and risk bounds are satisfied.
+- **Liveness**: all detected fault states eventually reach safe fallback.
+- **Auditability**: each privileged action eventually emits verifiable evidence.
+
+---
+
+## 3) Formalization and Reference Predicates
+
+Let `S` be states, `A` actions, `T` transitions, `C` controls, `R` reporting windows.
+
+- Transition admissibility: `P: S × A -> {0,1}`.
+- Evidence generation: `E: T -> H` where `H` is hash-linked event history.
+- Compliance satisfaction:
+  `Sat(i,j,c,r)=1` iff verifier `j` accepts proof `π` for statement `stmt(i,c,r)` and required commitments are included in the institution root for window `r`.
+
+Deterministic Supervisory Equivalence (DSE):
+for institutions `i1,i2` and jurisdictions `j1,j2`, `DSE=1` when shared control outcomes are equal under a harmonized predicate map `H(j1,j2)`.
+
+---
+
+## 4) zk Proof Pipeline and Verifier Federation Protocol
+
+### 4.1 Proof Pipeline
+
+1. Event normalization and canonical serialization.
+2. Commitment building (Merkle/polynomial commitment layer).
+3. zk circuit execution for mapped predicates.
+4. Recursive aggregation by supervisory reporting period.
+5. Jurisdiction-policy verification.
+6. Publication via supervisory evidence API.
+
+### 4.2 Minimum Security Properties
+
+- Completeness/soundness under published assumptions.
+- Non-malleability for submissions.
+- Domain separation across institution/jurisdiction contexts.
+- Forward security and key-rotation continuity.
+
+### 4.3 Federation Protocol
+
+- Node roles: national supervisor, regional supervisor, multilateral observer.
+- Threshold governance: `(n,t)` verification quorums.
+- Challenge protocol: objective disputes, evidentiary replay, adjudicated outcomes.
+- Sanctions: suspension/revocation based on treaty-defined proof of non-compliance.
+
+---
+
+## 5) Infrastructure Blueprint (Terraform + Multi-Region GPU + Kubernetes)
+
+### 5.1 Architecture Requirements
+
+- Regional data-residency partitioning.
+- Sovereign key custody and jurisdiction pinning.
+- Signed workload identity and deterministic build provenance.
+- Isolated resilience domains and regulator-read evidence endpoints.
+
+### 5.2 Deployment Blueprint (High-Level)
+
+- Terraform modules:
+  - `identity-and-kms`
+  - `regional-gpu-cluster`
+  - `evidence-stream`
+  - `verifier-gateway`
+- Kubernetes controls:
+  - signed-image admission,
+  - policy sidecars,
+  - immutable audit stream exporters,
+  - incident quarantine namespaces.
+
+---
+
+## 6) Regulatory Mapping for EU Financial Supervision
+
+### 6.1 EU AI Act
+
+Map risk management, traceability, post-market monitoring, and incident reporting to formal predicates and evidence interfaces.
+
+### 6.2 Basel Alignment
+
+Map model risk controls to attestable maturity indices and capital-impact-relevant governance evidence.
+
+### 6.3 DORA Alignment
+
+Map operational resilience requirements to continuity stress outputs and recoverability metrics.
+
+### 6.4 Regulator Dossier Package
+
+- Controls crosswalk matrix.
+- Proof summaries and assumption register.
+- Exception log with compensating controls.
+- Stress/recovery simulation results.
+- Independent verifier-federation attestation.
+
+---
+
+## 7) Treaty and Legal Recognition Architecture
+
+### 7.1 Global Accession & Compliance Protocol (GACP)
+
+- Entry: cryptographic capability + legal enforceability + audit independence.
+- Maintenance: periodic conformance proofs + dispute responsiveness.
+- Exit/suspension: proof-triggered and appeal-bounded procedures.
+
+### 7.2 Legal Recognition of zk Evidence
+
+Required legal research tracks:
+- admissibility standards,
+- burden-of-proof allocation,
+- liability apportionment,
+- explainability minimums for due process.
+
+### 7.3 Deterministic Supervisory Equivalence Governance
+
+Define when jurisdictions must accept equivalent outcomes and when local public-policy exceptions override equivalence.
+
+---
+
+## 8) Recoverability, Continuity, and Near-Criticality Governance
+
+### 8.1 Core Metrics
+
+- `RL` Reconstruction Latency.
+- `CIS` Continuity Integrity Score.
+- `PSR` Proof Survivability Ratio.
+- `CPI` Constitutional Preservation Index.
+
+### 8.2 Continuity Architecture
+
+- Multi-vault evidence replication with integrity checks.
+- Sovereign failover and legal isolation modes.
+- Mandatory game-day drills with supervisory witnessing.
+
+### 8.3 Criticality Forecasting
+
+Use early-warning indicators (autocorrelation rise, variance inflation, cascade motifs) to trigger pre-emptive constitutional safeguards.
+
+---
+
+## 9) Pilot Playbooks and Rollout Strategy
+
+### Phase 0 (0-6 months): Standardization
+- Shared ontology, schemas, control vocabulary.
+
+### Phase 1 (6-12 months): Bilateral sandboxes
+- Parallel run with legacy reporting and dispute logging.
+
+### Phase 2 (12-24 months): Regional federation
+- Interoperability and equivalence acceptance pilots.
+
+### Phase 3 (24-36 months): Multilateral accession
+- Treaty pilots, observer integration, and revocation mechanisms.
+
+Mandatory outputs per phase: architecture pack, legal annex, economic model, incident simulation report, and supervisor acceptance memo.
+
+---
+
+## 10) Governance Operating Model and Accountability
+
+### 10.1 Roles
+
+- Model Operator
+- Independent Assessor
+- Supervisory Verifier Node
+- Federation Council
+- Public Accountability Board
+
+### 10.2 RACI Baseline
+
+- Control definition: Council (A), Supervisors (R), Operators (C), Public Board (I).
+- Proof generation: Operators (A/R), Assessors (C), Supervisors (I).
+- Dispute adjudication: Supervisors (R), Council (A), Operators/Assessors (C).
+- Emergency suspension: Supervisors + Council (A/R), Board (I).
+
+---
+
+## 11) Critical Analysis: Main Risks and Failure Modes
+
+1. Formal-valid, policy-invalid outcomes.
+2. Legal-semantic drift vs encoded predicates.
+3. Verifier federation concentration/capture.
+4. Operational latency from proof and review overhead.
+5. Explainability deficits despite formal correctness.
+6. Crypto assumption degradation and implementation flaws.
+
+Mitigations: dual-track oversight (formal + interpretive), periodic predicate tribunals, anti-capture safeguards, and assumption stress testing.
+
+---
+
+## 12) Open Research Problems
+
+### Formal/Computational
+- Recursive proof efficiency for high-frequency supervision.
+- Verified legal-text-to-predicate compilers.
+- Cross-jurisdiction semantic composition under conflict.
+
+### Legal/Governance
+- Treaty-ready admissibility doctrine for zk evidence.
+- Redress mechanisms for formally valid but harmful outcomes.
+- Democratic legitimacy models for constitutional AI governance.
+
+### Recoverability/Science
+- Empirical calibration of RL/CIS/PSR/CPI in live environments.
+- Controlled validation protocols for resonance/recurrence hypotheses.
+- Reliability bounds for resilience forecasting near critical transitions.
+
+---
+
+## 13) Minimal Deliverables for First National Pilot
+
+1. Signed control ontology + predicate catalog.
+2. TLA+ baseline specs with model-check report.
+3. OSCAL profile bundle linked to evidence APIs.
+4. zk circuit inventory and assumptions register.
+5. Verifier node runbook and incident playbook.
+6. DSE crosswalk with at least one peer jurisdiction.
+7. Quarterly continuity drill report (RL/CIS/PSR/CPI).
+8. Public transparency and redress statement.
+
+---
+
+## 14) Conclusion
+
+A viable federated zk compliance regime requires synchronized progress in:
+- **formal verifiability** (truth of supervisory claims),
+- **institutional legitimacy** (legal and democratic acceptance),
+- **recoverable continuity** (resilience under disruption).
+
+The decisive implementation challenge is disciplined co-design of mathematics, law, operations, and multilateral governance.
+
+---
+
+## Annex A) Concrete Artifact Blueprints (Implementation Starters)
+
+### A.1 TLA+ Safety/Liveness Contract Set (Checklist)
+
+Minimum model-checked obligations before pilot go-live:
+1. `NoUnauthorizedActuation` (safety invariant).
+2. `EvidenceOnPrivilegeUse` (audit completeness).
+3. `FaultEventuallySafe` (recovery liveness).
+4. `NoPolicyBypassViaRollback` (state-version monotonicity).
+5. `QuorumConsistency` (no split-brain authorization).
+
+### A.2 OSCAL Catalog Starter Controls
+
+| Control ID | Control Family | Predicate | Evidence URI | Proof Statement |
+|---|---|---|---|---|
+| `AI-CONT-001` | Lineage Integrity | `P_lineage` | `urn:evidence:lineage` | `stmt_lineage_r` |
+| `AI-CONT-014` | Human Override | `P_override` | `urn:evidence:override` | `stmt_override_r` |
+| `AI-CONT-021` | Drift Bounds | `P_drift` | `urn:evidence:drift` | `stmt_drift_r` |
+| `AI-CONT-030` | Incident Escalation | `P_escalation` | `urn:evidence:incident` | `stmt_incident_r` |
+| `AI-CONT-044` | Recovery Readiness | `P_recovery` | `urn:evidence:recovery` | `stmt_recovery_r` |
+
+### A.3 zk Proof Submission Envelope (JSON Skeleton)
+
+```json
+{
+  "institution_id": "inst-001",
+  "jurisdiction": "EU",
+  "reporting_window": "2026-Q3",
+  "proof_bundle_hash": "0x...",
+  "proof_system": "groth16",
+  "public_inputs": ["stmt_lineage_r", "stmt_drift_r"],
+  "assumption_version": "crypto-assumptions-v1.2",
+  "evidence_root": "0x...",
+  "exceptions": [],
+  "signature": "sig..."
+}
+```
+
+### A.4 Kubernetes Governance Controls (Reference)
+
+- Enforce signed images and provenance attestations at admission time.
+- Require policy sidecar for all model-serving workloads.
+- Block outbound network egress from high-risk inference namespaces unless explicitly allowlisted.
+- Route audit events to immutable append-only evidence stream.
+- Auto-quarantine workloads exceeding drift or anomaly thresholds.
+
+### A.5 Terraform Module Contracts (Reference)
+
+- `identity-and-kms`: sovereign key hierarchy, rotation schedule, emergency recovery keys.
+- `regional-gpu-cluster`: zonal isolation, quota controls, deterministic node identity.
+- `evidence-stream`: append-only store, retention policy, cross-region replication.
+- `verifier-gateway`: regulator mTLS, signed query responses, policy-aware access control.
+
+---
+
+## Annex B) Supervisory Submission Dossier Template
+
+1. **Cover memo**: supervisory scope, reporting period, legal basis.
+2. **Control crosswalk**: EU AI Act / Basel / DORA mapping table.
+3. **Proof ledger**: proof IDs, statements, verification outcomes.
+4. **Exception register**: unresolved exceptions + compensating controls.
+5. **Resilience package**: RL/CIS/PSR/CPI trend and stress results.
+6. **Assumption register**: cryptographic, hardware, and process assumptions.
+7. **Independent review memo**: assessor findings and residual-risk statement.
+8. **Attestation block**: operator and verifier federation signatures.
+
+---
+
+## Annex C) Global Accession and Compliance Protocol (GACP) - Minimal Lifecycle
+
+### C.1 Accession Stages
+
+- **Stage 1 - Capability declaration**: legal and technical readiness disclosure.
+- **Stage 2 - Conformance trial**: supervised dry-run evidence submissions.
+- **Stage 3 - Conditional membership**: bounded production participation.
+- **Stage 4 - Full membership**: reciprocal equivalence recognition rights.
+
+### C.2 Suspension Triggers
+
+- Repeated verification failures above treaty threshold.
+- Refusal to provide challenge-response evidence.
+- Material misrepresentation of assumptions or evidence lineage.
+
+### C.3 Reinstatement Path
+
+- Root-cause remediation report.
+- Independent reassessment.
+- Demonstrated conformance across two consecutive reporting windows.
+
+---
+
+## Annex D) Research-to-Deployment KPI Scorecard
+
+| Dimension | KPI | Target Example |
+|---|---|---|
+| Formal assurance | Model-check pass rate | 100% of mandatory properties |
+| Cryptographic reliability | Proof verification success | >= 99.9% |
+| Supervisory timeliness | Submission SLA adherence | >= 98% |
+| Recoverability | RL under stress | <= policy bound |
+| Governance quality | Dispute closure within SLA | >= 95% |
+| Interoperability | DSE across shared controls | >= 0.90 |
+
+These KPIs provide a measurable bridge from research claims to supervisory-operational performance.
+
+
+## Editorial Notes
+
+- Mathematical symbols are intentionally lightweight for portability in regulator documentation workflows.
+- All templates are reference patterns and require jurisdictional/legal adaptation before operational use.
+- Annex artifacts are minimum starters, not exhaustive control catalogs.
+
+---
+
+## Annex E) Glossary of Core Terms
+
+- **Constitutional Invariant:** Non-overridable safety/governance constraint.
+- **DSE (Deterministic Supervisory Equivalence):** Cross-jurisdiction equivalence of supervisory outcomes under harmonized predicates.
+- **Evidence Root:** Cryptographic commitment to a reporting-window evidence set.
+- **GACP:** Global Accession and Compliance Protocol lifecycle for federation membership.
+- **Predicate Catalog:** Versioned set of formal compliance predicates linked to controls.
+- **Proof Bundle:** Verifiable package containing proof(s), statements, metadata, and signatures.
+- **Recoverability:** Capacity to reconstruct trustworthy operational/supervisory state after disruption.
+- **Verifier Federation:** Distributed set of supervisory verifier nodes across jurisdictions.
+
+---
+
+## Annex F) Traceability Matrix (Requirement -> Artifact -> Verification)
+
+| Requirement Theme | Primary Artifact | Verification Mechanism | Supervisory Evidence |
+|---|---|---|---|
+| Unauthorized actuation prevention | TLA+ safety properties + policy kernel | Model checking + runtime gate tests | Signed safety attestation |
+| Model lineage integrity | OSCAL control mapping + lineage predicate | zk proof verification | Lineage proof statement |
+| Drift containment | Drift predicate + quarantine policy | Threshold and incident replay tests | Drift logs + proof bundle |
+| Resilience and continuity | RL/CIS/PSR/CPI package | Stress simulation + replay drills | Continuity report |
+| Cross-jurisdiction interoperability | DSE crosswalk + GACP membership state | Federation challenge-response | Equivalence memo |
+| Legal admissibility readiness | Dossier package + assumption register | Independent assessor review | Attested submission dossier |
+
+This matrix is intended to anchor governance claims to concrete artifacts and independent verification paths.

--- a/docs/federated-zk-compliance/full_synthesis_v0.5.md
+++ b/docs/federated-zk-compliance/full_synthesis_v0.5.md
@@ -1,7 +1,7 @@
 # Federated Zero-Knowledge AI Compliance, Supervisory Governance, and Recoverability-Resonance Constitutional Frameworks
 
-**Document status:** Draft v0.5  
-**Intended audience:** Regulators, supervisory technologists, enterprise governance teams, policy/legal architects  
+**Document status:** Draft v0.5
+**Intended audience:** Regulators, supervisory technologists, enterprise governance teams, policy/legal architects
 **Usage:** Research-to-pilot reference blueprint (non-binding)
 
 

--- a/docs/federated-zk-compliance/validate_docs.py
+++ b/docs/federated-zk-compliance/validate_docs.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validator for federated-zk docs package.
+
+- Scans markdown files under docs/federated-zk-compliance/ plus top-level synthesis entry.
+- Verifies local markdown links resolve.
+- Verifies anchor references (same-file and cross-file) resolve to headings.
+- Emits non-zero exit code on missing links/anchors.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+import re
+
+ROOT = Path(__file__).resolve().parent
+REPO_ROOT = ROOT.parent.parent
+TOP_LEVEL_ENTRY = REPO_ROOT / "FEDERATED_ZK_AI_COMPLIANCE_RESEARCH_PROGRAM_SYNTHESIS.md"
+
+MD_LINK = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+HEADING = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
+
+
+def slugify(heading: str) -> str:
+    s = heading.strip().lower()
+    s = re.sub(r"[`*_]", "", s)
+    s = re.sub(r"[^a-z0-9\s-]", "", s)
+    s = re.sub(r"\s+", "-", s)
+    s = re.sub(r"-+", "-", s)
+    return s
+
+
+def extract_anchors(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    return {slugify(h) for h in HEADING.findall(text)}
+
+
+def is_external(link: str) -> bool:
+    return link.startswith(("http://", "https://", "mailto:"))
+
+
+def split_link(link: str) -> tuple[str, str]:
+    if "#" in link:
+        base, frag = link.split("#", 1)
+        return base, frag
+    return link, ""
+
+
+def resolve_target(source: Path, link_base: str) -> Path:
+    base = link_base or source.name
+    return (source.parent / base).resolve()
+
+
+def discover_markdown_files() -> list[Path]:
+    return sorted(ROOT.glob("*.md")) + [TOP_LEVEL_ENTRY]
+
+
+def validate(md_files: list[Path]) -> tuple[int, int, list[str]]:
+    errors: list[str] = []
+    checked = 0
+    anchor_cache: dict[Path, set[str]] = {}
+
+    for md in md_files:
+        if not md.exists():
+            errors.append(f"Missing expected file: {md}")
+            continue
+
+        text = md.read_text(encoding="utf-8")
+        for m in MD_LINK.finditer(text):
+            checked += 1
+            link = m.group(1).strip()
+            if is_external(link):
+                continue
+
+            base, frag = split_link(link)
+            target = resolve_target(md, base)
+
+            if not target.exists():
+                errors.append(f"{md}: missing link target -> {link}")
+                continue
+
+            if frag and target.suffix.lower() == ".md":
+                if target not in anchor_cache:
+                    anchor_cache[target] = extract_anchors(target)
+                if slugify(frag) not in anchor_cache[target]:
+                    errors.append(f"{md}: missing anchor '#{frag}' in {target}")
+
+    return checked, len(errors), errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate federated-zk markdown links/anchors.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail if no links are checked (safety against mis-scoped runs).",
+    )
+    args = parser.parse_args()
+
+    checked, error_count, errors = validate(discover_markdown_files())
+
+    if error_count:
+        print("FAIL")
+        print(f"Checked links: {checked}")
+        for err in errors:
+            print(err)
+        return 1
+
+    if args.strict and checked == 0:
+        print("FAIL")
+        print("Checked links: 0")
+        print("Strict mode requires at least one checked link.")
+        return 1
+
+    print("PASS: all checked markdown links and anchors resolve")
+    print(f"Checked links: {checked}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_federated_zk_validate_docs.py
+++ b/tests/test_federated_zk_validate_docs.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+import importlib.util
+import tempfile
+import unittest
+
+
+def load_module():
+    mod_path = Path("docs/federated-zk-compliance/validate_docs.py")
+    spec = importlib.util.spec_from_file_location("validate_docs", mod_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class FederatedZkValidateDocsTests(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+
+    def test_is_external_variants(self):
+        self.assertTrue(self.module.is_external("https://example.com"))
+        self.assertTrue(self.module.is_external("http://example.com"))
+        self.assertTrue(self.module.is_external("mailto:test@example.com"))
+        self.assertFalse(self.module.is_external("#section"))
+        self.assertFalse(self.module.is_external("README.md"))
+
+    def test_resolve_target_relative_path(self):
+        source = Path("docs/federated-zk-compliance/README.md").resolve()
+        target = self.module.resolve_target(source, "_index.md")
+        self.assertEqual(target.name, "_index.md")
+        self.assertTrue(target.exists())
+
+    def test_slugify_and_anchor_extraction(self):
+        p = Path("docs/federated-zk-compliance/_index.md")
+        anchors = self.module.extract_anchors(p)
+        self.assertIn("quick-navigation", anchors)
+        self.assertEqual(
+            self.module.slugify("01 — Layered Architecture and Formal Model"),
+            "01-layered-architecture-and-formal-model",
+        )
+
+    def test_validate_fails_on_missing_anchor(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            a = root / "a.md"
+            b = root / "b.md"
+            a.write_text("# Doc A\n\n[Broken](b.md#nope)\n", encoding="utf-8")
+            b.write_text("# Target\n", encoding="utf-8")
+
+            checked, error_count, errors = self.module.validate([a])
+            self.assertEqual(checked, 1)
+            self.assertEqual(error_count, 1)
+            self.assertIn("missing anchor", errors[0])
+
+    def test_validate_passes_for_valid_local_links(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            a = root / "a.md"
+            b = root / "b.md"
+            a.write_text("# Doc A\n\n[Good](b.md#target)\n", encoding="utf-8")
+            b.write_text("# Target\n", encoding="utf-8")
+
+            checked, error_count, errors = self.module.validate([a, b])
+            self.assertEqual(checked, 1)
+            self.assertEqual(error_count, 0)
+            self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce a modularized v0.5 documentation package to replace an oversized monolithic synthesis and improve reviewability and ownership. 
- Ensure internal markdown cross-links and anchors in the new package are correct and stay correct as the docs evolve. 
- Provide an automated validation step in CI so documentation link/anchor regressions are caught on pushes and pull requests. 

### Description
- Add a new modular docs package under `docs/federated-zk-compliance/` including `README.md`, `_index.md`, `01`–`06` workstream modules, `full_synthesis_v0.5.md`, and `CHANGELOG.md` and a top-level navigation entry `FEDERATED_ZK_AI_COMPLIANCE_RESEARCH_PROGRAM_SYNTHESIS.md`.
- Add a markdown validator script `docs/federated-zk-compliance/validate_docs.py` that verifies local markdown link targets and heading anchors and supports `--strict` to require at least one checked link.
- Add unit tests in `tests/test_federated_zk_validate_docs.py` that exercise `is_external`, `resolve_target`, `slugify`/anchor extraction, and validation pass/fail scenarios.
- Add a GitHub Actions workflow `.github/workflows/federated-zk-docs-validation.yml` that runs the tests and then executes `validate_docs.py --strict` on relevant pushes and pull requests.

### Testing
- Ran the new unit tests with `python -m unittest discover -s tests -p 'test_federated_zk_validate_docs.py'`, and they passed. 
- Ran the docs validator in strict mode with `python docs/federated-zk-compliance/validate_docs.py --strict` against the added package, and it completed without error (no missing links/anchors detected). 
- Configured CI job `Federated ZK Docs Validation` to execute both the unit tests and the strict validator on PRs and pushes to the docs paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05a52214c48329beade4d7e7f514ac)