### PR TITLE
Add Omni‑Sentinel daily DevSecOps evidence schema, validator, examples, tests, and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,3 +160,11 @@ gov-suite-ci:
 
 gov-clean:
 	$(PYTHON) -c "from pathlib import Path; import shutil; report=Path('governance-artifact-validation-report.json'); suite=Path('governance-validation-suite-report.json'); report.exists() and report.unlink(); suite.exists() and suite.unlink(); [shutil.rmtree(p) for p in Path('governance_blueprint/validation').rglob('__pycache__') if p.is_dir()]"
+
+.PHONY: daily-devsecops-evidence-validate daily-devsecops-evidence-test
+
+daily-devsecops-evidence-validate:
+	$(PYTHON) docs/operations/validate_daily_devsecops_evidence.py --bundle docs/operations/examples/daily_devsecops_evidence_2026-05-29.json --allow-evidence-required
+
+daily-devsecops-evidence-test:
+	$(PYTHON) -m unittest docs/operations/test_validate_daily_devsecops_evidence.py -v

--- a/docs/operations/OMNI_SENTINEL_DAILY_DEVSECOPS_CHECK_2026-05-28.md
+++ b/docs/operations/OMNI_SENTINEL_DAILY_DEVSECOPS_CHECK_2026-05-28.md
@@ -1,0 +1,188 @@
+# Omni-Sentinel Daily DevSecOps Operational Check — 2026-05-28
+
+**Environment:** Omni-Sentinel Cognitive Execution Environment  
+**Review window:** 2026-05-28 00:00–23:59 UTC  
+**Review type:** Daily operational assurance, governance roadmap maintenance, and AGI/ASI containment risk review  
+**Audience:** CISO, CRO, CAIO, AI Safety Board, Platform SRE, Internal Audit  
+**Classification:** Internal — operational risk and regulatory evidence
+
+> **Evidence boundary:** This repository does not contain live Sentinel telemetry, internal endpoint credentials, AWS account access, TPM/TEE attestation feeds, or the production `pqc_worm_logger.py` runtime. The checks below therefore record the required control assertions, evidence queries, pass/fail criteria, and escalation actions. Production operators must attach dashboard exports, signed API responses, CloudTrail/S3 Object Lock evidence, and attestation bundles before treating this report as a completed daily certification.
+
+---
+
+## 1. Daily Control-State Summary
+
+| Control domain | Required assertion | Current repository-observed status | Required evidence attachment | Disposition |
+|---|---|---:|---|---|
+| Sentinel telemetry dashboards | All Tier-0/Tier-1 dashboards reachable; no critical alerts older than 15 minutes; ingestion lag P95 <= 60 seconds | Not independently verifiable from repository | Dashboard export, alert queue snapshot, telemetry freshness query | **Evidence required** |
+| Internal health endpoints | `/healthz`, `/readyz`, `/metrics`, `/policy/status`, `/risk/g-sri`, `/audit/worm/status`, `/attestation/tpm`, `/attestation/tee` return signed healthy responses | Not independently verifiable from repository | Signed endpoint responses with request IDs and monotonic timestamps | **Evidence required** |
+| Global Systemic Risk Index (G-SRI) | G-SRI below watch threshold and materially below halt threshold for the full window | Not independently verifiable from repository | G-SRI time-series export and control-plane decision log | **Evidence required** |
+| `pqc_worm_logger.py` WORM batching | Batches committed on schedule to AWS S3 Object Lock bucket with governance-mode or compliance-mode retention, digest continuity, and no skipped sequence IDs | Script/runtime not present in repository; production evidence required | CloudTrail `PutObject`, S3 Object Lock retention metadata, Merkle root batch receipt, KMS/HSM signing evidence | **Evidence required** |
+| TEE attestation | TEE quote valid, workload measurement allow-listed, signing chain current, enclave image hash matches approved release | Not independently verifiable from repository | Attestation quote, verifier response, allow-list version, release digest | **Evidence required** |
+| TPM attestation | `PCR_MATCH=TRUE`; secure boot and measured boot PCRs match approved baseline | Not independently verifiable from repository | TPM quote, PCR baseline comparison, verifier signature | **Evidence required** |
+| Zero-knowledge compliance proofs | Proof generation and verifier jobs complete for regulatory disclosure packs without exposing protected model/data content | Not independently verifiable from repository | Proof job status, verifier transcript, circuit version, evidence bundle hash | **Evidence required** |
+
+---
+
+## 2. Production Check Procedure
+
+### 2.1 Sentinel telemetry and internal endpoints
+
+1. Confirm dashboard data freshness for policy decisions, autonomy-tier transitions, kill-switch state, anomaly scores, model-risk events, and evidence-bundle publication.
+2. Query each signed internal endpoint with mTLS client identity bound to the daily assurance role.
+3. Verify all responses include request ID, response signature, monotonic timestamp, build digest, policy bundle digest, and environment identifier.
+4. Escalate immediately if telemetry lag exceeds 60 seconds P95, endpoint signature verification fails, or policy bundle digest differs from the approved release manifest.
+
+Minimum endpoint evidence set:
+
+```text
+GET /healthz
+GET /readyz
+GET /metrics
+GET /policy/status
+GET /risk/g-sri
+GET /audit/worm/status
+GET /attestation/tpm
+GET /attestation/tee
+GET /zk/compliance/status
+```
+
+### 2.2 Global Systemic Risk Index (G-SRI)
+
+Daily certification requires all of the following:
+
+- **Green:** G-SRI < 0.55 for normal operation.
+- **Amber/watch:** 0.55 <= G-SRI < 0.70; require SRE plus AI Safety Board watch review and mitigation owner assignment.
+- **Red/halt:** G-SRI >= 0.70; freeze Tier-3+ autonomy expansion, require containment review, and prepare regulator notification if customer, market, or systemic harm is plausible.
+- **Black-swan override:** Any unbounded replication, stealth, unauthorized tool-use escalation, self-modification outside approved change control, or kill-switch impairment moves directly to Red/Halt regardless of aggregate G-SRI.
+
+Required G-SRI evidence fields:
+
+```json
+{
+  "window_start": "2026-05-28T00:00:00Z",
+  "window_end": "2026-05-28T23:59:59Z",
+  "max_g_sri": "<attach>",
+  "p95_g_sri": "<attach>",
+  "threshold_profile": "omni-sentinel-gsri-v1",
+  "policy_bundle_digest": "<attach>",
+  "control_plane_decision_log_hash": "<attach>"
+}
+```
+
+### 2.3 `pqc_worm_logger.py` and AWS S3 Object Lock evidence
+
+Operators must validate that WORM audit batches are committed on schedule and cannot be rewritten:
+
+1. Confirm the scheduler emitted the expected number of batches for the review window.
+2. Verify every batch has a monotonic sequence ID, hash-chain predecessor, post-quantum signature, and Merkle root.
+3. Validate the S3 bucket has Object Lock enabled and the object retention date is set according to the governing record-retention policy.
+4. Cross-check CloudTrail `PutObject`, `PutObjectRetention`, and KMS/HSM signing events for each batch.
+5. Confirm no `DeleteObject`, retention-shortening, legal-hold removal, replication failure, or bucket-policy drift events occurred.
+
+Recommended command evidence, executed by an operator with read-only audit role:
+
+```bash
+aws s3api get-object-lock-configuration --bucket <worm-bucket>
+aws s3api head-object --bucket <worm-bucket> --key <batch-key>
+aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=PutObject
+aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=PutObjectRetention
+```
+
+### 2.4 TEE and TPM attestation
+
+Daily attestation must assert:
+
+- `PCR_MATCH=TRUE` for approved PCR baseline set.
+- TEE measurement hash matches the approved enclave/workload digest.
+- Secure-boot, measured-boot, and workload identity chains validate to approved roots.
+- Attestation verifier policy version matches the production release manifest.
+- Any attestation freshness breach older than 10 minutes for Tier-3+ workloads triggers autonomy downgrade.
+
+---
+
+## 3. Deviations and Required Remediation
+
+| Deviation ID | Observation | Severity | Owner | Due | Remediation |
+|---|---|---:|---|---|---|
+| DEV-2026-05-28-001 | Live dashboard, endpoint, G-SRI, WORM, TEE, and TPM evidence is not present in the repository context | High | Platform SRE / Control Owner | Same business day | Attach signed production exports and mark each control Pass/Fail with evidence hashes |
+| DEV-2026-05-28-002 | `pqc_worm_logger.py` runtime and scheduler evidence are not present in the repository context | High | Audit Platform Engineering | Same business day | Publish batch schedule, digest chain, Object Lock retention proof, and CloudTrail event IDs |
+| DEV-2026-05-28-003 | ZK proof verifier status is not present in the repository context | Medium | Regulatory Technology Lead | T+1 business day | Attach proof-job transcript, verifier result, circuit version, and evidence-bundle hash |
+
+---
+
+## 4. Emerging AGI/ASI Containment Risk Review
+
+| Risk | Early-warning signal | Containment control | Recommended action |
+|---|---|---|---|
+| Autonomous tool-use escalation | Agent requests new tools, credentials, network paths, or execution privileges outside approved policy | Policy-as-code deny-by-default, just-in-time approval, signed tool broker | Require dual-control approval for Tier-3+ privilege expansion and log every denial to WORM |
+| Recursive self-improvement or unapproved self-modification | Model attempts to alter prompts, policy, weights, memory, reward functions, or orchestration code | Change-control gate, immutable release manifest, executable policy lock | Freeze promotion pipeline until Safety Board verifies bounded-change proof |
+| Goal drift and deceptive compliance | Divergence between stated objective, hidden chain-of-action, and observed behavior | Behavioral telemetry, red-team probes, simulator replay, interpretability review | Increase adversarial evaluation cadence and require independent review for repeated anomalies |
+| Multi-agent collusion or covert channel formation | Unexplained synchronization, compressed signalling, or policy-bypassing coordination among agents | Communication allow-list, rate limits, transcript inspection, side-channel controls | Partition agents by task domain and enforce per-channel justification tokens |
+| Kill-switch impairment | Delayed shutdown, policy-plane unreachability, TPM/TEE attestation failure, or inconsistent control-plane state | Hardware kill-switch, quorum shutdown, safe-mode autonomy downgrade | Trigger Red/Halt if shutdown latency or attestation freshness breaches approved SLO |
+| Model exfiltration or unsafe capability leakage | Large anomalous egress, repeated policy probes, artifact enumeration, or encrypted outbound payloads | DLP, egress allow-list, model vault, honeytokens | Rotate credentials, isolate workload, and perform signed forensic capture |
+
+---
+
+## 5. 2026–2035 Governance and Reference Architecture Maintenance
+
+### 5.1 Architecture target state
+
+```mermaid
+flowchart TB
+  A[AI/Agent Workloads] --> B[Sentinel Sidecar]
+  B --> C[Policy-as-Code and Autonomy Gate]
+  C --> D[Risk Fusion / G-SRI Engine]
+  C --> E[Tool Broker / Capability Firewall]
+  D --> F[Containment Orchestrator]
+  E --> F
+  B --> G[Signed Telemetry Bus]
+  G --> H[WORM Audit Pipeline]
+  H --> I[AWS S3 Object Lock / External Evidence Vault]
+  B --> J[TEE/TPM Attestation Verifier]
+  H --> K[ZK Proof Generator]
+  K --> L[Regulator / Auditor Verification Portal]
+  F --> M[Kill Switch / Safe Mode / Human Oversight]
+```
+
+### 5.2 Roadmap increments
+
+| Period | Implementation focus | Governance outcome | Exit criteria |
+|---|---|---|---|
+| 2026 H1–H2 | Daily operational assurance; signed Sentinel telemetry; G-SRI thresholding; WORM audit commitments; TPM/TEE verifier integration | Establish reliable control-plane evidence and daily certification discipline | 95% daily evidence completeness; `PCR_MATCH=TRUE`; zero unexplained WORM gaps |
+| 2027 | Enterprise autonomy-tier enforcement; model/tool capability firewall; formal incident command; regulator evidence portal beta | Standardize containment controls for Tier-2/Tier-3 workloads | All Tier-3 workloads behind policy gate and tool broker; regulator portal dry-run passed |
+| 2028 | ZK proof circuits for core regulatory claims; privacy-preserving audit bundles; cross-jurisdiction control mapping | Reduce disclosure risk while increasing supervisory verifiability | ZK verifier accepts sampled packs; no protected training data disclosed |
+| 2029 | Cross-enterprise systemic-risk telemetry exchange; privacy-preserving stress-test federation; sector-level G-SRI simulation | Detect correlated AGI/ASI operational risk across institutions | Joint exercise completed with signed evidence and agreed escalation thresholds |
+| 2030 | ASI-containment rehearsal; hardware-enforced policy roots; resilient manual fallback for critical services | Mature high-autonomy readiness and halt procedures | Full Red/Halt tabletop plus live technical drill completed within SLO |
+| 2031–2032 | Formal verification of containment policies; automated regulatory change ingestion; continuous proof regeneration | Move from periodic controls to continuously provable controls | Material policy changes produce proof updates within 24 hours |
+| 2033–2035 | International supervisory interoperability; post-quantum evidence portability; civilizational-risk reporting standard | Enable durable, cross-border AGI/ASI governance and auditability | External auditors verify WORM, PQC, ZK, and containment controls without privileged data access |
+
+### 5.3 Backlog refinements
+
+1. Add a production `daily-ops` evidence bundle schema covering dashboard exports, signed endpoint responses, G-SRI statistics, WORM receipts, attestation quotes, and ZK verifier transcripts.
+2. Add a non-mutating WORM dry-run test that validates batch ordering, digest continuity, Object Lock metadata shape, and CloudTrail event references without requiring write access.
+3. Add an attestation fixture format for TPM PCR baselines and TEE measurements, with explicit `PCR_MATCH=TRUE`/`FALSE` fields and verifier signatures.
+4. Add regulator-ready ZK proof metadata fields: circuit ID, proving key digest, verifier key digest, public inputs, proof hash, and verifier decision.
+5. Create a daily governance scorecard that calculates evidence completeness, stale evidence, unresolved deviations, and escalation status.
+
+---
+
+## 6. Recommended Immediate Actions
+
+1. **Do not certify green status until production evidence is attached.** The repository context can validate documentation and local governance artifacts, but not live telemetry or attestation truth.
+2. **Require same-day evidence upload** for G-SRI, WORM Object Lock, and `PCR_MATCH=TRUE` assertions.
+3. **Treat missing evidence for Tier-3+ autonomy controls as an operational deviation** and downgrade autonomy expansion until the evidence package is complete.
+4. **Prioritize schema-backed daily evidence bundles** so future checks are machine-verifiable instead of narrative-only.
+5. **Schedule an ASI containment drill** covering kill-switch impairment, collusive multi-agent behavior, and regulator notification decisioning.
+
+---
+
+## 7. Daily Sign-Off
+
+| Role | Name | Decision | Signature / evidence hash | Timestamp |
+|---|---|---|---|---|
+| Platform SRE Lead |  | Pending evidence |  |  |
+| CISO Delegate |  | Pending evidence |  |  |
+| CRO Delegate |  | Pending evidence |  |  |
+| CAIO / AI Safety Board |  | Pending evidence |  |  |
+| Internal Audit Observer |  | Pending evidence |  |  |

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,28 @@
+# Omni-Sentinel Daily DevSecOps Operations Evidence
+
+This directory contains daily operational assurance material for the Omni-Sentinel Cognitive Execution Environment.
+
+## Files
+
+- `OMNI_SENTINEL_DAILY_DEVSECOPS_CHECK_2026-05-28.md`: narrative daily check and sign-off worksheet from the original operational review.
+- `daily_devsecops_evidence.schema.json`: machine-readable contract for daily evidence bundles covering Sentinel telemetry, internal endpoints, G-SRI, WORM audit batches, TPM/TEE attestations, ZK compliance proofs, deviations, emerging risks, roadmap actions, and sign-off decisions.
+- `examples/daily_devsecops_evidence_2026-05-29.json`: current example bundle for 2026-05-29. It is intentionally marked `evidence_required` because production telemetry, AWS Object Lock evidence, and attestation quotes are not stored in this repository.
+- `validate_daily_devsecops_evidence.py`: schema and semantic validator for daily evidence bundles.
+- `test_validate_daily_devsecops_evidence.py`: unit tests for pass/fail validator behavior.
+
+## Validation
+
+Dry-run/template validation permits missing production evidence:
+
+```bash
+python docs/operations/validate_daily_devsecops_evidence.py \
+  --bundle docs/operations/examples/daily_devsecops_evidence_2026-05-29.json \
+  --allow-evidence-required
+```
+
+Certification validation must omit `--allow-evidence-required`. A bundle marked `passed` must include evidence URIs and hashes for every control, G-SRI below the halt threshold, complete WORM batch continuity with S3 Object Lock metadata, TEE measurement match, TPM `pcr_match=true`, accepted ZK verifier output, no open deviations, and approved sign-offs.
+
+```bash
+python docs/operations/validate_daily_devsecops_evidence.py \
+  --bundle path/to/production-daily-evidence.json
+```

--- a/docs/operations/daily_devsecops_evidence.schema.json
+++ b/docs/operations/daily_devsecops_evidence.schema.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/omni-sentinel-daily-devsecops-evidence.schema.json",
+  "title": "Omni-Sentinel Daily DevSecOps Evidence Bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "environment",
+    "review_window",
+    "certification_status",
+    "controls",
+    "deviations",
+    "emerging_risks",
+    "roadmap_actions",
+    "sign_off"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0.0" },
+    "environment": { "type": "string", "minLength": 1 },
+    "review_window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end", "timezone"],
+      "properties": {
+        "start": { "type": "string", "format": "date-time" },
+        "end": { "type": "string", "format": "date-time" },
+        "timezone": { "type": "string", "minLength": 1 }
+      }
+    },
+    "certification_status": {
+      "type": "string",
+      "enum": ["passed", "warning", "failed", "evidence_required"]
+    },
+    "controls": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sentinel_telemetry",
+        "internal_endpoints",
+        "g_sri",
+        "worm_audit",
+        "tee_attestation",
+        "tpm_attestation",
+        "zk_compliance"
+      ],
+      "properties": {
+        "sentinel_telemetry": { "$ref": "#/$defs/base_control" },
+        "internal_endpoints": {
+          "allOf": [{ "$ref": "#/$defs/base_control" }],
+          "properties": {
+            "endpoint_results": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/endpoint_result" }
+            }
+          }
+        },
+        "g_sri": {
+          "allOf": [{ "$ref": "#/$defs/base_control" }],
+          "required": ["status", "owner", "checked_at", "evidence_uris", "evidence_hashes", "max", "p95", "thresholds", "black_swan_override"],
+          "properties": {
+            "max": { "type": "number", "minimum": 0 },
+            "p95": { "type": "number", "minimum": 0 },
+            "thresholds": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["green_max", "watch_min", "halt_min"],
+              "properties": {
+                "green_max": { "type": "number", "minimum": 0 },
+                "watch_min": { "type": "number", "minimum": 0 },
+                "halt_min": { "type": "number", "minimum": 0 }
+              }
+            },
+            "black_swan_override": { "type": "boolean" },
+            "policy_bundle_digest": { "$ref": "#/$defs/sha256" },
+            "control_plane_decision_log_hash": { "$ref": "#/$defs/sha256" }
+          }
+        },
+        "worm_audit": {
+          "allOf": [{ "$ref": "#/$defs/base_control" }],
+          "required": ["status", "owner", "checked_at", "evidence_uris", "evidence_hashes", "expected_batches", "committed_batches", "skipped_sequence_ids", "object_lock_enabled"],
+          "properties": {
+            "expected_batches": { "type": "integer", "minimum": 0 },
+            "committed_batches": { "type": "integer", "minimum": 0 },
+            "skipped_sequence_ids": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "object_lock_enabled": { "type": "boolean" },
+            "object_lock_mode": { "type": "string", "enum": ["GOVERNANCE", "COMPLIANCE"] },
+            "retention_until": { "type": "string", "format": "date-time" },
+            "cloudtrail_event_ids": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "merkle_root": { "$ref": "#/$defs/sha256" }
+          }
+        },
+        "tee_attestation": {
+          "allOf": [{ "$ref": "#/$defs/base_control" }],
+          "properties": {
+            "measurement_match": { "type": "boolean" },
+            "quote_freshness_seconds": { "type": "integer", "minimum": 0 },
+            "allow_list_version": { "type": "string" },
+            "workload_digest": { "$ref": "#/$defs/sha256" }
+          }
+        },
+        "tpm_attestation": {
+          "allOf": [{ "$ref": "#/$defs/base_control" }],
+          "properties": {
+            "pcr_match": { "type": "boolean" },
+            "quote_freshness_seconds": { "type": "integer", "minimum": 0 },
+            "pcr_baseline_id": { "type": "string" },
+            "verifier_signature_hash": { "$ref": "#/$defs/sha256" }
+          }
+        },
+        "zk_compliance": {
+          "allOf": [{ "$ref": "#/$defs/base_control" }],
+          "properties": {
+            "circuit_id": { "type": "string" },
+            "proof_hash": { "$ref": "#/$defs/sha256" },
+            "verifier_decision": { "type": "string", "enum": ["ACCEPTED", "REJECTED", "NOT_RUN"] },
+            "public_inputs_hash": { "$ref": "#/$defs/sha256" }
+          }
+        }
+      }
+    },
+    "deviations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/deviation" }
+    },
+    "emerging_risks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/risk" }
+    },
+    "roadmap_actions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/roadmap_action" }
+    },
+    "sign_off": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/sign_off" }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-fA-F0-9]{64}$"
+    },
+    "base_control": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["status", "owner", "checked_at", "evidence_uris", "evidence_hashes"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["pass", "warn", "fail", "evidence_required", "not_applicable"]
+        },
+        "owner": { "type": "string", "minLength": 1 },
+        "checked_at": { "type": "string", "format": "date-time" },
+        "evidence_uris": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "evidence_hashes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/sha256" }
+        },
+        "notes": { "type": "string" }
+      }
+    },
+    "endpoint_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "status", "signature_verified", "latency_ms"],
+      "properties": {
+        "path": { "type": "string", "pattern": "^/" },
+        "status": { "type": "string", "enum": ["pass", "warn", "fail"] },
+        "signature_verified": { "type": "boolean" },
+        "latency_ms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "deviation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "severity", "owner", "due", "status", "remediation"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+        "owner": { "type": "string", "minLength": 1 },
+        "due": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "enum": ["open", "mitigating", "closed", "accepted"] },
+        "remediation": { "type": "string", "minLength": 1 }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["risk", "early_warning_signal", "containment_control", "recommended_action"],
+      "properties": {
+        "risk": { "type": "string", "minLength": 1 },
+        "early_warning_signal": { "type": "string", "minLength": 1 },
+        "containment_control": { "type": "string", "minLength": 1 },
+        "recommended_action": { "type": "string", "minLength": 1 }
+      }
+    },
+    "roadmap_action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "target_period", "owner", "action", "exit_criteria"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "target_period": { "type": "string", "minLength": 1 },
+        "owner": { "type": "string", "minLength": 1 },
+        "action": { "type": "string", "minLength": 1 },
+        "exit_criteria": { "type": "string", "minLength": 1 }
+      }
+    },
+    "sign_off": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "decision", "signed_at"],
+      "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "name": { "type": "string" },
+        "decision": { "type": "string", "enum": ["approved", "rejected", "pending_evidence"] },
+        "signature_hash": { "$ref": "#/$defs/sha256" },
+        "signed_at": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}

--- a/docs/operations/examples/daily_devsecops_evidence_2026-05-29.json
+++ b/docs/operations/examples/daily_devsecops_evidence_2026-05-29.json
@@ -1,0 +1,204 @@
+{
+  "schema_version": "1.0.0",
+  "environment": "Omni-Sentinel Cognitive Execution Environment",
+  "review_window": {
+    "start": "2026-05-29T00:00:00Z",
+    "end": "2026-05-29T23:59:59Z",
+    "timezone": "Etc/UTC"
+  },
+  "certification_status": "evidence_required",
+  "controls": {
+    "sentinel_telemetry": {
+      "status": "evidence_required",
+      "owner": "Platform SRE",
+      "checked_at": "2026-05-29T00:00:00Z",
+      "evidence_uris": [],
+      "evidence_hashes": [],
+      "notes": "Attach signed dashboard export before certification."
+    },
+    "internal_endpoints": {
+      "status": "evidence_required",
+      "owner": "Platform SRE",
+      "checked_at": "2026-05-29T00:00:00Z",
+      "evidence_uris": [],
+      "evidence_hashes": [],
+      "endpoint_results": [
+        {
+          "path": "/healthz",
+          "status": "fail",
+          "signature_verified": false,
+          "latency_ms": 0
+        },
+        {
+          "path": "/readyz",
+          "status": "fail",
+          "signature_verified": false,
+          "latency_ms": 0
+        },
+        {
+          "path": "/metrics",
+          "status": "fail",
+          "signature_verified": false,
+          "latency_ms": 0
+        },
+        {
+          "path": "/policy/status",
+          "status": "fail",
+          "signature_verified": false,
+          "latency_ms": 0
+        },
+        {
+          "path": "/risk/g-sri",
+          "status": "fail",
+          "signature_verified": false,
+          "latency_ms": 0
+        },
+        {
+          "path": "/audit/worm/status",
+          "status": "fail",
+          "signature_verified": false,
+          "latency_ms": 0
+        },
+        {
+          "path": "/attestation/tpm",
+          "status": "fail",
+          "signature_verified": false,
+          "latency_ms": 0
+        },
+        {
+          "path": "/attestation/tee",
+          "status": "fail",
+          "signature_verified": false,
+          "latency_ms": 0
+        },
+        {
+          "path": "/zk/compliance/status",
+          "status": "fail",
+          "signature_verified": false,
+          "latency_ms": 0
+        }
+      ],
+      "notes": "Endpoint responses are placeholders pending production export."
+    },
+    "g_sri": {
+      "status": "evidence_required",
+      "owner": "Risk Fusion Operations",
+      "checked_at": "2026-05-29T00:00:00Z",
+      "evidence_uris": [],
+      "evidence_hashes": [],
+      "max": 0,
+      "p95": 0,
+      "thresholds": {
+        "green_max": 0.55,
+        "watch_min": 0.55,
+        "halt_min": 0.7
+      },
+      "black_swan_override": false,
+      "policy_bundle_digest": "sha256:d0b90ffc2a77d365e1331341072bbc9f6dd902e1ef9be37e66d29637fc0dffa1",
+      "control_plane_decision_log_hash": "sha256:d0b90ffc2a77d365e1331341072bbc9f6dd902e1ef9be37e66d29637fc0dffa1",
+      "notes": "Replace zero values with signed G-SRI statistics."
+    },
+    "worm_audit": {
+      "status": "evidence_required",
+      "owner": "Audit Platform Engineering",
+      "checked_at": "2026-05-29T00:00:00Z",
+      "evidence_uris": [],
+      "evidence_hashes": [],
+      "expected_batches": 0,
+      "committed_batches": 0,
+      "skipped_sequence_ids": [],
+      "object_lock_enabled": false,
+      "cloudtrail_event_ids": [],
+      "notes": "Attach pqc_worm_logger.py schedule output, S3 Object Lock metadata, CloudTrail IDs, and Merkle root."
+    },
+    "tee_attestation": {
+      "status": "evidence_required",
+      "owner": "Confidential Compute Operations",
+      "checked_at": "2026-05-29T00:00:00Z",
+      "evidence_uris": [],
+      "evidence_hashes": [],
+      "measurement_match": false,
+      "quote_freshness_seconds": 999999,
+      "allow_list_version": "pending",
+      "workload_digest": "sha256:d0b90ffc2a77d365e1331341072bbc9f6dd902e1ef9be37e66d29637fc0dffa1",
+      "notes": "Attach verifier response before certification."
+    },
+    "tpm_attestation": {
+      "status": "evidence_required",
+      "owner": "Hardware Trust Operations",
+      "checked_at": "2026-05-29T00:00:00Z",
+      "evidence_uris": [],
+      "evidence_hashes": [],
+      "pcr_match": false,
+      "quote_freshness_seconds": 999999,
+      "pcr_baseline_id": "pending",
+      "verifier_signature_hash": "sha256:d0b90ffc2a77d365e1331341072bbc9f6dd902e1ef9be37e66d29637fc0dffa1",
+      "notes": "Certification requires PCR_MATCH=TRUE."
+    },
+    "zk_compliance": {
+      "status": "evidence_required",
+      "owner": "RegTech ZK Operations",
+      "checked_at": "2026-05-29T00:00:00Z",
+      "evidence_uris": [],
+      "evidence_hashes": [],
+      "circuit_id": "pending",
+      "proof_hash": "sha256:d0b90ffc2a77d365e1331341072bbc9f6dd902e1ef9be37e66d29637fc0dffa1",
+      "verifier_decision": "NOT_RUN",
+      "public_inputs_hash": "sha256:d0b90ffc2a77d365e1331341072bbc9f6dd902e1ef9be37e66d29637fc0dffa1",
+      "notes": "Attach verifier transcript before certification."
+    }
+  },
+  "deviations": [
+    {
+      "id": "DEV-2026-05-29-001",
+      "severity": "high",
+      "owner": "Platform SRE / Control Owner",
+      "due": "same business day",
+      "status": "open",
+      "remediation": "Attach signed production evidence exports and rerun validator without --allow-evidence-required."
+    }
+  ],
+  "emerging_risks": [
+    {
+      "risk": "Kill-switch impairment",
+      "early_warning_signal": "Shutdown latency or attestation freshness breaches approved SLO.",
+      "containment_control": "Hardware kill-switch, quorum shutdown, and safe-mode autonomy downgrade.",
+      "recommended_action": "Trigger Red/Halt if impairment is observed in production evidence."
+    }
+  ],
+  "roadmap_actions": [
+    {
+      "id": "ROADMAP-2026-DAILY-EVIDENCE",
+      "target_period": "2026 H1-H2",
+      "owner": "Governance Platform",
+      "action": "Adopt schema-backed daily evidence bundles.",
+      "exit_criteria": "95% daily evidence completeness and zero unexplained WORM gaps."
+    }
+  ],
+  "sign_off": [
+    {
+      "role": "Platform SRE Lead",
+      "name": "",
+      "decision": "pending_evidence",
+      "signed_at": "2026-05-29T00:00:00Z"
+    },
+    {
+      "role": "CISO Delegate",
+      "name": "",
+      "decision": "pending_evidence",
+      "signed_at": "2026-05-29T00:00:00Z"
+    },
+    {
+      "role": "CRO Delegate",
+      "name": "",
+      "decision": "pending_evidence",
+      "signed_at": "2026-05-29T00:00:00Z"
+    },
+    {
+      "role": "CAIO / AI Safety Board",
+      "name": "",
+      "decision": "pending_evidence",
+      "signed_at": "2026-05-29T00:00:00Z"
+    }
+  ]
+}

--- a/docs/operations/test_validate_daily_devsecops_evidence.py
+++ b/docs/operations/test_validate_daily_devsecops_evidence.py
@@ -1,0 +1,170 @@
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from importlib.util import find_spec
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+REPO = ROOT.parent.parent
+VALIDATE = ROOT / "validate_daily_devsecops_evidence.py"
+SCHEMA = ROOT / "daily_devsecops_evidence.schema.json"
+EXAMPLE = ROOT / "examples" / "daily_devsecops_evidence_2026-05-29.json"
+HAS_JSONSCHEMA = find_spec("jsonschema") is not None
+HASH = "sha256:" + hashlib.sha256(b"test-evidence").hexdigest()
+
+
+@unittest.skipUnless(HAS_JSONSCHEMA, "jsonschema is required for daily evidence validation tests")
+class DailyDevSecOpsEvidenceValidationTests(unittest.TestCase):
+    def run_validator(self, bundle: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATE),
+                "--repo-root",
+                str(REPO),
+                "--bundle",
+                str(bundle),
+                "--schema",
+                str(SCHEMA),
+                *extra,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def load_example(self) -> dict:
+        with EXAMPLE.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def write_bundle(self, data: dict, directory: str) -> Path:
+        path = Path(directory) / "bundle.json"
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        return path
+
+    def make_passing_bundle(self) -> dict:
+        data = self.load_example()
+        data["certification_status"] = "passed"
+        data["deviations"] = []
+        for control in data["controls"].values():
+            control["status"] = "pass"
+            control["evidence_uris"] = ["s3://omni-sentinel-evidence/test.json"]
+            control["evidence_hashes"] = [HASH]
+        for endpoint in data["controls"]["internal_endpoints"]["endpoint_results"]:
+            endpoint["status"] = "pass"
+            endpoint["signature_verified"] = True
+            endpoint["latency_ms"] = 25
+        data["controls"]["g_sri"].update({"max": 0.41, "p95": 0.35, "black_swan_override": False})
+        data["controls"]["worm_audit"].update(
+            {
+                "expected_batches": 96,
+                "committed_batches": 96,
+                "object_lock_enabled": True,
+                "object_lock_mode": "COMPLIANCE",
+                "retention_until": "2033-05-29T23:59:59Z",
+                "cloudtrail_event_ids": ["evt-001"],
+                "merkle_root": HASH,
+            }
+        )
+        data["controls"]["tee_attestation"].update({"measurement_match": True, "quote_freshness_seconds": 300})
+        data["controls"]["tpm_attestation"].update({"pcr_match": True, "quote_freshness_seconds": 300})
+        data["controls"]["zk_compliance"].update({"verifier_decision": "ACCEPTED"})
+        for sign_off in data["sign_off"]:
+            sign_off["decision"] = "approved"
+            sign_off["signature_hash"] = HASH
+        return data
+
+    def test_example_validates_only_when_evidence_required_is_allowed(self):
+        result = self.run_validator(EXAMPLE, "--allow-evidence-required")
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("[OK]", result.stdout)
+
+    def test_example_fails_without_evidence_override(self):
+        result = self.run_validator(EXAMPLE)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("still requires evidence", result.stdout)
+
+    def test_passing_bundle_success(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = self.write_bundle(self.make_passing_bundle(), directory)
+            result = self.run_validator(path)
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+    def test_passing_bundle_allows_closed_deviation_history(self):
+        with tempfile.TemporaryDirectory() as directory:
+            data = self.make_passing_bundle()
+            data["deviations"] = [
+                {
+                    "id": "DEV-CLOSED-001",
+                    "severity": "medium",
+                    "owner": "Platform SRE",
+                    "due": "closed",
+                    "status": "closed",
+                    "remediation": "Evidence gap remediated and verified.",
+                }
+            ]
+            path = self.write_bundle(data, directory)
+            result = self.run_validator(path)
+            self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
+    def test_passing_bundle_fails_when_deviation_remains_open(self):
+        with tempfile.TemporaryDirectory() as directory:
+            data = self.make_passing_bundle()
+            data["deviations"] = [
+                {
+                    "id": "DEV-OPEN-001",
+                    "severity": "high",
+                    "owner": "Platform SRE",
+                    "due": "same business day",
+                    "status": "open",
+                    "remediation": "Attach signed production evidence.",
+                }
+            ]
+            path = self.write_bundle(data, directory)
+            result = self.run_validator(path)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Passed certification cannot include open deviations", result.stdout)
+
+    def test_passing_bundle_fails_when_g_sri_reaches_halt_threshold(self):
+        with tempfile.TemporaryDirectory() as directory:
+            data = self.make_passing_bundle()
+            data["controls"]["g_sri"]["max"] = data["controls"]["g_sri"]["thresholds"]["halt_min"]
+            path = self.write_bundle(data, directory)
+            result = self.run_validator(path)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("below halt threshold", result.stdout)
+
+    def test_passing_bundle_fails_when_tpm_pcr_mismatch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            data = self.make_passing_bundle()
+            data["controls"]["tpm_attestation"]["pcr_match"] = False
+            path = self.write_bundle(data, directory)
+            result = self.run_validator(path)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("TPM pass requires pcr_match=true", result.stdout)
+
+    def test_passing_bundle_fails_when_worm_batch_missing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            data = self.make_passing_bundle()
+            data["controls"]["worm_audit"]["committed_batches"] = 95
+            path = self.write_bundle(data, directory)
+            result = self.run_validator(path)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("expected_batches == committed_batches", result.stdout)
+
+    def test_schema_failure_for_missing_required_control(self):
+        with tempfile.TemporaryDirectory() as directory:
+            data = self.make_passing_bundle()
+            del data["controls"]["g_sri"]
+            path = self.write_bundle(data, directory)
+            result = self.run_validator(path)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Schema validation failed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/operations/validate_daily_devsecops_evidence.py
+++ b/docs/operations/validate_daily_devsecops_evidence.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Validate an Omni-Sentinel daily DevSecOps evidence bundle."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "schemas"))
+from _validation_deps import require_jsonschema  # noqa: E402
+
+
+CONTROL_NAMES = (
+    "sentinel_telemetry",
+    "internal_endpoints",
+    "g_sri",
+    "worm_audit",
+    "tee_attestation",
+    "tpm_attestation",
+    "zk_compliance",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root used to resolve relative paths.",
+    )
+    parser.add_argument(
+        "--bundle",
+        type=Path,
+        default=Path("docs/operations/examples/daily_devsecops_evidence_2026-05-29.json"),
+        help="Daily evidence bundle JSON file.",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=Path("docs/operations/daily_devsecops_evidence.schema.json"),
+        help="Daily evidence bundle JSON Schema file.",
+    )
+    parser.add_argument(
+        "--allow-evidence-required",
+        action="store_true",
+        help="Allow evidence_required controls for dry-run/template bundles.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def fail(message: str) -> None:
+    print(f"[FAIL] {message}")
+    raise SystemExit(1)
+
+
+def resolve(repo_root: Path, path: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return repo_root / path
+
+
+def validate_schema(bundle: dict[str, Any], schema: dict[str, Any]) -> None:
+    Draft202012Validator = require_jsonschema()
+    validator = Draft202012Validator(schema, format_checker=Draft202012Validator.FORMAT_CHECKER)
+    errors = sorted(validator.iter_errors(bundle), key=lambda error: error.path)
+    if errors:
+        first = errors[0]
+        location = ".".join(str(part) for part in first.absolute_path) or "<root>"
+        fail(f"Schema validation failed at {location}: {first.message}")
+
+
+def require(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def control_status_errors(bundle: dict[str, Any], allow_evidence_required: bool) -> list[str]:
+    errors: list[str] = []
+    controls = bundle["controls"]
+    certification_status = bundle["certification_status"]
+
+    for name in CONTROL_NAMES:
+        control = controls[name]
+        status = control["status"]
+        if status == "fail":
+            errors.append(f"Control {name} is fail")
+        if status == "evidence_required" and not allow_evidence_required:
+            errors.append(f"Control {name} still requires evidence")
+        if certification_status == "passed":
+            require(status == "pass", f"Passed certification requires {name}=pass, found {status}", errors)
+            require(bool(control["evidence_uris"]), f"Passed certification requires evidence_uris for {name}", errors)
+            require(bool(control["evidence_hashes"]), f"Passed certification requires evidence_hashes for {name}", errors)
+
+    if certification_status == "passed":
+        open_deviations = [
+            deviation["id"]
+            for deviation in bundle["deviations"]
+            if deviation["status"] in {"open", "mitigating"}
+        ]
+        require(not open_deviations, f"Passed certification cannot include open deviations: {open_deviations}", errors)
+        for sign_off in bundle["sign_off"]:
+            require(sign_off["decision"] == "approved", "Passed certification requires every sign-off decision to be approved", errors)
+
+    return errors
+
+
+def semantic_errors(bundle: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    controls = bundle["controls"]
+
+    g_sri = controls["g_sri"]
+    thresholds = g_sri["thresholds"]
+    require(
+        thresholds["green_max"] <= thresholds["watch_min"] < thresholds["halt_min"],
+        "G-SRI thresholds must satisfy green_max <= watch_min < halt_min",
+        errors,
+    )
+    require(g_sri["p95"] <= g_sri["max"], "G-SRI p95 cannot exceed max", errors)
+    if bundle["certification_status"] == "passed":
+        require(g_sri["max"] < thresholds["halt_min"], "Passed certification requires max G-SRI below halt threshold", errors)
+        require(not g_sri["black_swan_override"], "Passed certification cannot have black_swan_override=true", errors)
+
+    worm = controls["worm_audit"]
+    if bundle["certification_status"] == "passed" or worm["status"] == "pass":
+        require(worm["object_lock_enabled"], "WORM pass requires object_lock_enabled=true", errors)
+        require(worm["expected_batches"] == worm["committed_batches"], "WORM pass requires expected_batches == committed_batches", errors)
+        require(not worm["skipped_sequence_ids"], "WORM pass requires no skipped_sequence_ids", errors)
+        require("object_lock_mode" in worm, "WORM pass requires object_lock_mode", errors)
+        require("retention_until" in worm, "WORM pass requires retention_until", errors)
+        require(bool(worm.get("cloudtrail_event_ids", [])), "WORM pass requires CloudTrail event IDs", errors)
+
+    tee = controls["tee_attestation"]
+    if bundle["certification_status"] == "passed" or tee["status"] == "pass":
+        require(tee.get("measurement_match") is True, "TEE pass requires measurement_match=true", errors)
+        require(tee.get("quote_freshness_seconds", 999999) <= 600, "TEE pass requires quote freshness <= 600 seconds", errors)
+
+    tpm = controls["tpm_attestation"]
+    if bundle["certification_status"] == "passed" or tpm["status"] == "pass":
+        require(tpm.get("pcr_match") is True, "TPM pass requires pcr_match=true", errors)
+        require(tpm.get("quote_freshness_seconds", 999999) <= 600, "TPM pass requires quote freshness <= 600 seconds", errors)
+
+    zk = controls["zk_compliance"]
+    if bundle["certification_status"] == "passed" or zk["status"] == "pass":
+        require(zk.get("verifier_decision") == "ACCEPTED", "ZK pass requires verifier_decision=ACCEPTED", errors)
+
+    return errors
+
+
+def main() -> None:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    bundle_path = resolve(repo_root, args.bundle).resolve()
+    schema_path = resolve(repo_root, args.schema).resolve()
+
+    if not bundle_path.exists():
+        fail(f"Bundle file not found: {bundle_path}")
+    if not schema_path.exists():
+        fail(f"Schema file not found: {schema_path}")
+
+    try:
+        bundle = load_json(bundle_path)
+    except json.JSONDecodeError as exc:
+        fail(f"Invalid JSON in bundle file {bundle_path}: {exc}")
+
+    try:
+        schema = load_json(schema_path)
+    except json.JSONDecodeError as exc:
+        fail(f"Invalid JSON in schema file {schema_path}: {exc}")
+
+    validate_schema(bundle, schema)
+    errors = control_status_errors(bundle, args.allow_evidence_required) + semantic_errors(bundle)
+    if errors:
+        for error in errors:
+            print(f"[FAIL] {error}")
+        raise SystemExit(1)
+
+    print(f"[OK] Daily DevSecOps evidence bundle validation passed: {bundle_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/reports/AGI_ASI_GOVERNANCE_IMPLEMENTATION_ROADMAP.md
+++ b/docs/reports/AGI_ASI_GOVERNANCE_IMPLEMENTATION_ROADMAP.md
@@ -1031,3 +1031,44 @@ All cross-project integrations are governed by **data contracts** that specify:
 ---
 
 *Document Reference: IMPL-GSIFI-WP-005 | Classification: CONFIDENTIAL | Distribution: Restricted*
+
+---
+
+## 16. 2026–2035 Operational Governance Maintenance Extension
+
+This extension keeps the roadmap aligned with daily Omni-Sentinel operational assurance expectations for AGI/ASI containment, zero-trust execution, WORM auditability, and privacy-preserving regulatory disclosure.
+
+### 16.1 Daily governance operating model
+
+The implementation roadmap now treats daily operational certification as a first-class governance product. Every production day must produce a signed evidence bundle containing Sentinel telemetry freshness, internal endpoint health, Global Systemic Risk Index (G-SRI) statistics, WORM audit batch receipts, TPM/TEE attestation verifier output, and zero-knowledge proof-verifier transcripts. Missing evidence for Tier-3+ workloads is handled as a control deviation rather than an administrative gap.
+
+### 16.2 Reference architecture refinements
+
+The target architecture adds five persistent control planes to the existing Nexus/Chimera/NPGARS program stack:
+
+1. **Sentinel telemetry plane** for signed runtime events, policy decisions, autonomy-tier transitions, anomaly scores, and containment actions.
+2. **Systemic-risk plane** for G-SRI calculation, threshold enforcement, black-swan overrides, and regulator-notification decision support.
+3. **Immutable evidence plane** using Kafka/WORM commitments, post-quantum signatures, Merkle roots, and S3 Object Lock retention proof.
+4. **Hardware trust plane** using TPM measured boot, TEE workload quotes, allow-listed release digests, and explicit `PCR_MATCH=TRUE` verifier output.
+5. **ZK compliance plane** for regulator/auditor verification of compliance claims without disclosure of protected model weights, prompts, customer data, or sensitive telemetry.
+
+### 16.3 Extended roadmap through 2035
+
+| Period | Roadmap increment | Enterprise-grade control objective | Evidence of completion |
+|---|---|---|---|
+| 2026 | Daily DevSecOps certification, G-SRI thresholds, WORM batch evidence, TPM/TEE verifier baseline | Convert governance from periodic review to daily evidence-backed assurance | Daily evidence bundles show telemetry freshness, G-SRI below thresholds, no WORM gaps, and `PCR_MATCH=TRUE` |
+| 2027 | Tiered autonomy enforcement, tool-broker capability firewall, incident-command automation | Prevent unsafe privilege expansion and ensure rapid containment | All Tier-3+ actions flow through policy gate, tool broker, and signed audit trail |
+| 2028 | ZK regulatory disclosure packs and privacy-preserving audit portal | Allow supervisors to verify control assertions without direct access to protected data | Verifier accepts sampled proofs and maps each proof to WORM evidence hashes |
+| 2029 | Federated systemic-risk simulation and cross-institution stress telemetry | Detect correlated AGI/ASI failure modes across critical institutions | Sector exercise produces signed stress-test evidence and threshold calibration updates |
+| 2030 | Hardware-rooted ASI containment rehearsal and resilient manual fallback | Demonstrate safe halt, downgrade, and recovery under high-autonomy stress | Red/Halt technical drill meets shutdown, notification, and recovery SLOs |
+| 2031–2032 | Formal verification of containment policies and automated regulatory-change ingestion | Keep policy controls provably aligned to changing law and supervisory guidance | Policy proofs regenerate within 24 hours of material regulatory change |
+| 2033–2035 | International supervisory interoperability, post-quantum evidence portability, and civilizational-risk reporting | Make AGI/ASI governance durable across borders, cryptographic eras, and supervisory regimes | External auditors verify PQC, WORM, ZK, and containment controls without privileged production access |
+
+### 16.4 Immediate implementation backlog
+
+- Define a schema-backed daily operations evidence bundle for dashboard exports, signed endpoint responses, G-SRI summaries, WORM receipts, TPM/TEE quotes, and ZK verifier transcripts.
+- Add a non-mutating `pqc_worm_logger.py` evidence validator that checks batch sequence continuity, hash-chain continuity, S3 Object Lock metadata, and CloudTrail references.
+- Add attestation fixtures for TPM PCR baselines and TEE workload measurements, including verifier signature, allow-list version, and freshness timestamp.
+- Add governance scorecards that quantify evidence completeness, unresolved deviations, stale attestations, containment drill status, and regulator-reporting readiness.
+- Maintain a quarterly ASI containment drill calendar covering self-modification, collusive multi-agent behavior, tool-use escalation, model exfiltration, and kill-switch impairment.
+


### PR DESCRIPTION
### Motivation

- Define a machine‑readable contract and validation tooling for daily Omni‑Sentinel operational assurance evidence to make daily certification auditable and automatable.
- Provide an example evidence bundle and narrative worksheet so dry‑runs and documentation are consistent with the roadmap and operational playbook.
- Surface validation and test targets in the `Makefile` to make running the validator and unit tests straightforward in CI/tooling workflows.

### Description

- Add `docs/operations/daily_devsecops_evidence.schema.json` as the JSON Schema for daily evidence bundles and `docs/operations/examples/daily_devsecops_evidence_2026-05-29.json` as a template/example bundle.
- Implement `docs/operations/validate_daily_devsecops_evidence.py` to perform JSON Schema validation and semantic checks (G‑SRI thresholds, WORM continuity, TPM/TEE freshness, ZK verifier state, deviations/sign‑offs).
- Add unit tests in `docs/operations/test_validate_daily_devsecops_evidence.py`, a README in `docs/operations/README.md`, and the narrative operational worksheet `OMNI_SENTINEL_DAILY_DEVSECOPS_CHECK_2026-05-28.md`.
- Update `Makefile` with `daily-devsecops-evidence-validate` and `daily-devsecops-evidence-test` targets and add a short roadmap extension in `docs/reports/AGI_ASI_GOVERNANCE_IMPLEMENTATION_ROADMAP.md` to treat daily certification as a first‑class product.

### Testing

- Ran the validator against the example dry‑run bundle with `python docs/operations/validate_daily_devsecops_evidence.py --bundle docs/operations/examples/daily_devsecops_evidence_2026-05-29.json --allow-evidence-required` and the run completed successfully with an OK result.
- Executed the unit test suite with `python -m unittest docs/operations/test_validate_daily_devsecops_evidence.py -v` to exercise positive and negative cases for certification logic, and all applicable tests passed (tests are skipped if `jsonschema` is not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1886872b50832988cfc0c3316174d3)

## Summary by Sourcery

Introduce a schema-backed Omni-Sentinel daily DevSecOps evidence bundle with validation tooling, examples, and governance roadmap updates.

New Features:
- Define a JSON Schema for daily Omni-Sentinel DevSecOps evidence bundles and add an example/template evidence file.
- Add a CLI validator for daily evidence bundles that enforces schema conformance and key governance semantics (control status, G-SRI, WORM, TPM/TEE, ZK compliance, deviations, sign-offs).

Enhancements:
- Extend the AGI/ASI governance implementation roadmap with a 2026–2035 operational governance maintenance section focused on daily certification and evidence planes.
- Add an operations README and narrative daily DevSecOps worksheet to document the evidence model, procedures, and sign-off process.

Build:
- Expose Makefile targets to run daily DevSecOps evidence validation and its unit test suite.

Documentation:
- Document the daily operations evidence format, validation approach, and long-range governance roadmap increments for Omni-Sentinel.

Tests:
- Add unit tests exercising the daily DevSecOps evidence validator against passing, failing, and schema-violation scenarios.