### PR TITLE
Add GIEN Phase VI-δ Daily Supervisory Dossier and register in governance index

### DIFF
--- a/rag-agentic-dashboard/public/gien-phase-vi-delta-supervisory-dossier.html
+++ b/rag-agentic-dashboard/public/gien-phase-vi-delta-supervisory-dossier.html
@@ -1,0 +1,559 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GIEN Phase VI-δ Sentinel AI Governance Stack v2.4 — Daily Supervisory Dossier</title>
+  <meta name="description" content="Daily regulator-ready DevSecOps and AI governance operational verification dossier for GIEN Phase VI-delta, Omni-Sentinel Mesh v4.0, and SCP v3.0 across G-SIFIs and Fortune 500 financial institutions.">
+  <style>
+    :root {
+      --bg: #08111f;
+      --panel: #111827;
+      --panel-2: #172033;
+      --panel-3: #0d1728;
+      --text: #e5edf7;
+      --muted: #9fb0c7;
+      --border: #263449;
+      --blue: #60a5fa;
+      --green: #34d399;
+      --gold: #fbbf24;
+      --red: #f87171;
+      --violet: #a78bfa;
+      --cyan: #22d3ee;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: linear-gradient(180deg, #07101e 0%, #0b1220 100%);
+      color: var(--text);
+      font-family: Inter, "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      line-height: 1.58;
+    }
+
+    a { color: #93c5fd; }
+    a:hover { color: var(--cyan); }
+
+    .skip-link {
+      position: absolute;
+      left: -999px;
+      top: 0;
+      background: var(--gold);
+      color: #111827;
+      padding: 0.5rem 1rem;
+      border-radius: 0 0 0.5rem 0;
+      z-index: 100;
+    }
+
+    .skip-link:focus { left: 0; }
+
+    header {
+      padding: 2.5rem clamp(1rem, 4vw, 3rem);
+      border-bottom: 1px solid var(--border);
+      background: radial-gradient(circle at 82% 18%, rgba(96, 165, 250, 0.18), transparent 34%), #0b1220;
+    }
+
+    header h1 {
+      margin: 0;
+      max-width: 1100px;
+      color: #bfdbfe;
+      font-size: clamp(1.7rem, 3vw, 3rem);
+      line-height: 1.08;
+    }
+
+    .meta {
+      margin-top: 0.85rem;
+      color: var(--muted);
+    }
+
+    .badge-row { margin-top: 0.9rem; }
+
+    .badge {
+      display: inline-block;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 0.2rem 0.65rem;
+      margin: 0.12rem;
+      color: #dbeafe;
+      background: #10213a;
+      font-size: 0.78rem;
+    }
+
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: rgba(9, 17, 31, 0.94);
+      backdrop-filter: blur(8px);
+      border-bottom: 1px solid var(--border);
+      padding: 0.65rem clamp(1rem, 3vw, 2rem);
+      display: flex;
+      gap: 0.45rem;
+      flex-wrap: wrap;
+    }
+
+    nav a {
+      color: var(--muted);
+      text-decoration: none;
+      border: 1px solid var(--border);
+      border-radius: 0.55rem;
+      padding: 0.35rem 0.6rem;
+      font-size: 0.82rem;
+    }
+
+    nav a:hover, nav a:focus {
+      color: var(--blue);
+      border-color: var(--blue);
+      outline: none;
+    }
+
+    .container {
+      max-width: 1280px;
+      margin: auto;
+      padding: 1.5rem clamp(1rem, 3vw, 2rem) 4rem;
+    }
+
+    section {
+      margin: 1.2rem 0 1.7rem;
+      padding: 1.1rem;
+      background: rgba(17, 24, 39, 0.88);
+      border: 1px solid var(--border);
+      border-radius: 1rem;
+    }
+
+    h2 {
+      margin: 0.2rem 0 1rem;
+      color: var(--blue);
+      font-size: 1.3rem;
+    }
+
+    h3 {
+      color: #93c5fd;
+      margin: 1rem 0 0.45rem;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 0.8rem;
+    }
+
+    .card {
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      border-radius: 0.85rem;
+      padding: 0.9rem;
+    }
+
+    .kpi {
+      font-size: 1.7rem;
+      font-weight: 800;
+      color: var(--green);
+    }
+
+    .label {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 0.6rem 0;
+      font-size: 0.88rem;
+    }
+
+    th, td {
+      border-bottom: 1px solid var(--border);
+      padding: 0.6rem;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      color: #bfdbfe;
+      background: #132039;
+    }
+
+    .ok { color: var(--green); font-weight: 700; }
+    .watch { color: var(--gold); font-weight: 700; }
+    .critical { color: var(--red); font-weight: 700; }
+
+    .seal {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: #07101e;
+      border: 1px dashed var(--cyan);
+      padding: 0.85rem;
+      border-radius: 0.7rem;
+      color: #a7f3d0;
+      overflow-wrap: anywhere;
+    }
+
+    .callout {
+      border-left: 4px solid var(--gold);
+      padding: 0.85rem 1rem;
+      background: #1f1a0d;
+      border-radius: 0.5rem;
+      margin-top: 1rem;
+    }
+
+    .small { color: var(--muted); font-size: 0.86rem; }
+    ul { padding-left: 1.2rem; }
+
+    @media (max-width: 720px) {
+      table { display: block; overflow-x: auto; }
+      nav { position: static; }
+    }
+
+    @media print {
+      nav, .skip-link { display: none; }
+      body { background: #fff; color: #111; }
+      section, .card { break-inside: avoid; background: #fff; color: #111; }
+      a { color: #0f3f8f; }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+
+  <header>
+    <h1>Daily Regulator-Ready DevSecOps and AI Governance Supervisory Dossier</h1>
+    <p class="meta">
+      GIEN Phase VI-δ Sentinel AI Governance Stack v2.4 · Omni-Sentinel Mesh v4.0 · SCP v3.0 ·
+      governance epochs 2026–2035 and 2035–2100+ · issued 2026-07-18 UTC
+    </p>
+    <div class="badge-row" aria-label="Covered frameworks">
+      <span class="badge">G-SIFI / Fortune 500</span>
+      <span class="badge">EU AI Act Annex IV</span>
+      <span class="badge">NIST AI RMF 1.0 + AI 600-1</span>
+      <span class="badge">ISO/IEC 42001 AIMS</span>
+      <span class="badge">Basel III/IV</span>
+      <span class="badge">SR 26-2 / SR 11-7 transition</span>
+      <span class="badge">DORA / NIS2</span>
+      <span class="badge">GDPR Article 22</span>
+      <span class="badge">SEC Rule 17a-4</span>
+    </div>
+  </header>
+
+  <nav aria-label="Dossier sections">
+    <a href="#exec">Executive brief</a>
+    <a href="#verification">Control verification</a>
+    <a href="#alignment">Regulatory alignment</a>
+    <a href="#mesh">Planetary mesh</a>
+    <a href="#roadmap">Roadmap</a>
+    <a href="#sealed">Sealed dossier</a>
+    <a href="#epochs">Epoch analysis</a>
+    <a href="#sources">Reference anchors</a>
+  </nav>
+
+  <main id="main" class="container">
+    <section id="exec">
+      <h2>1. Consolidated Supervisory Brief</h2>
+      <div class="grid">
+        <div class="card">
+          <div class="kpi">Green</div>
+          <div class="label">Daily operating posture</div>
+          <p>
+            No unresolved critical control breaks are recorded for the synthetic supervisory baseline.
+            Production institutions must replace this placeholder with signed telemetry from CMDB,
+            SIEM, SOAR, model-risk management, AIMS, records-management, and incident systems.
+          </p>
+        </div>
+        <div class="card">
+          <div class="kpi">24h</div>
+          <div class="label">Evidence freshness target</div>
+          <p>
+            Runtime, policy, identity, cyber, model, data, and third-party attestations are expected
+            to be collected daily, hashed, retained, and mapped to named accountable owners.
+          </p>
+        </div>
+        <div class="card">
+          <div class="kpi">2100+</div>
+          <div class="label">Governance horizon</div>
+          <p>
+            The dossier separates immediate supervisory readiness from long-horizon civilizational
+            AI governance, treaty-grade coordination, and systemic-risk escalation mechanisms.
+          </p>
+        </div>
+      </div>
+      <div class="callout">
+        <strong>Supervisory use:</strong> This page is a regulator-ready operating dossier template and daily
+        brief pack. It is not a legal opinion, regulatory filing, or substitute for board-approved
+        policies, supervisory determinations, or jurisdiction-specific counsel.
+      </div>
+    </section>
+
+    <section id="verification">
+      <h2>2. GIEN Control Domain Verification</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Domain</th>
+            <th>Daily verification evidence</th>
+            <th>Status</th>
+            <th>Supervisory guidance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Model inventory and materiality</td>
+            <td>Authoritative inventory, tiering, owner attestation, dependency graph, and aggregate model-risk map.</td>
+            <td class="ok">Ready</td>
+            <td>Escalate unmapped GenAI or agentic systems into AI-system inventory even where model-risk guidance scope differs.</td>
+          </tr>
+          <tr>
+            <td>Secure SDLC / DevSecOps</td>
+            <td>SBOM, SAST, DAST, IaC scan, secrets scan, CI provenance, and signed release manifest.</td>
+            <td class="ok">Ready</td>
+            <td>Block promotion on critical vulnerabilities, unsigned artifacts, unapproved model endpoints, or missing rollback plans.</td>
+          </tr>
+          <tr>
+            <td>Policy-as-code</td>
+            <td>OPA/Sentinel decision logs, exception register, test coverage, and separation-of-duty evidence.</td>
+            <td class="ok">Ready</td>
+            <td>Require dual-control override approval for high-impact AI decisions and customer-affecting automation.</td>
+          </tr>
+          <tr>
+            <td>Data governance</td>
+            <td>Lineage, lawful basis, consent flags, retention class, privacy impact assessment, and bias checks.</td>
+            <td class="watch">Watch</td>
+            <td>Reconcile GDPR Article 22, ECOA adverse-action explainability, data minimization, and cross-border transfer rules.</td>
+          </tr>
+          <tr>
+            <td>Operational resilience</td>
+            <td>RTO/RPO tests, cyber tabletop, incident evidence, third-party exit plan, and immutable logs.</td>
+            <td class="ok">Ready</td>
+            <td>Align AI incident handling with DORA ICT incident, NIS2 essential-entity, and SEC books-and-records requirements.</td>
+          </tr>
+          <tr>
+            <td>Human oversight</td>
+            <td>Decision-rights matrix, SMCR owner, challenge records, kill-switch drills, and conduct-risk assessment.</td>
+            <td class="ok">Ready</td>
+            <td>Maintain named senior accountability for model, AI, cyber, privacy, and customer-outcome risk.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="alignment">
+      <h2>3. Multi-Jurisdictional Regulatory and Supervisory Alignment</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Framework</th>
+            <th>Dossier evidence pack</th>
+            <th>Examiner-ready brief</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>EU AI Act Annex IV</td>
+            <td>System description, intended purpose, versions, architecture, data, development process, testing, risk management, human oversight, and post-market monitoring.</td>
+            <td>Maintain a continuously updated technical file before high-risk deployment and after material changes.</td>
+          </tr>
+          <tr>
+            <td>NIST AI RMF 1.0 / AI 600-1</td>
+            <td>Govern, Map, Measure, and Manage controls plus GenAI profile hazards, evaluation protocol, red-team results, and content provenance.</td>
+            <td>Use as the cross-sector risk taxonomy bridging engineering, risk, audit, and board reporting.</td>
+          </tr>
+          <tr>
+            <td>ISO/IEC 42001 AIMS</td>
+            <td>AIMS scope, policy, objectives, risk treatment plan, internal audit, management review, and supplier controls.</td>
+            <td>Treat certification evidence as management-system evidence, not as proof of legal compliance.</td>
+          </tr>
+          <tr>
+            <td>Basel III/IV</td>
+            <td>Capital, liquidity, operational-risk, stress-test, and model-dependency impact analysis.</td>
+            <td>Map AI control failures to capital, liquidity, recovery, resolution, and operational-risk scenarios.</td>
+          </tr>
+          <tr>
+            <td>SR 26-2 / SR 11-7 transition</td>
+            <td>Model lifecycle governance, independent validation, risk-based review cadence, aggregate model risk, limitations, and use controls.</td>
+            <td>Track the 2026 revised model-risk guidance and maintain legacy SR 11-7 traceability where required by contracts, local policies, or non-U.S. supervisory references.</td>
+          </tr>
+          <tr>
+            <td>DORA / NIS2</td>
+            <td>ICT risk management, incident classification, threat-led penetration testing, third-party register, and cyber governance.</td>
+            <td>Integrate AI platform outages, model supply-chain events, and managed-service failures into ICT resilience playbooks.</td>
+          </tr>
+          <tr>
+            <td>GDPR Article 22 / ECOA</td>
+            <td>Automated-decision inventory, meaningful information, human review path, adverse-action reason codes, and fairness evidence.</td>
+            <td>Test customer journeys for contestability, explanation quality, disparate impact, and record retention.</td>
+          </tr>
+          <tr>
+            <td>MAS/HKMA FEAT, FCA SMCR and Consumer Duty, HKMA Fintech 2030</td>
+            <td>Fairness, ethics, accountability, transparency, senior-manager responsibilities, customer-outcome monitoring, and digital-strategy controls.</td>
+            <td>Evidence local responsible-AI principles with measurable outcomes and accountable executives.</td>
+          </tr>
+          <tr>
+            <td>SEC Rule 17a-4</td>
+            <td>WORM retention, audit trails, legal hold, indexing, and supervisory communication capture.</td>
+            <td>Preserve prompts, model outputs, approvals, customer-affecting decisions, and policy decisions where records rules apply.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="mesh">
+      <h2>4. Planetary Governance Mesh and Treaty-Grade Mechanisms</h2>
+      <div class="grid">
+        <div class="card">
+          <h3>Omni-Sentinel Mesh v4.0</h3>
+          <ul>
+            <li>Federated control plane with jurisdictional policy shards and institution-local enforcement.</li>
+            <li>Cryptographic evidence exchange using selective disclosure, WORM retention, and regulator nodes.</li>
+            <li>Systemic-risk telemetry for correlated AI, cyber, liquidity, fraud, and market-abuse events.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>SCP v3.0 supervisory control plane</h3>
+          <ul>
+            <li>Board, senior manager, model risk, cyber, privacy, legal, and audit command hierarchy.</li>
+            <li>Kill-switch, graceful degradation, ring-fenced safe mode, and customer-remediation workflows.</li>
+            <li>Cross-border escalation with data-localization and privilege boundaries.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Treaty-grade mechanisms</h3>
+          <ul>
+            <li>Common incident severity ontology and cross-border notification clocks.</li>
+            <li>Reciprocal audit protocols for critical AI financial infrastructure.</li>
+            <li>Public-interest safeguards for frontier and autonomous financial AI.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="roadmap">
+      <h2>5. Strategic and Technical Roadmap Status</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Phase</th>
+            <th>Scope</th>
+            <th>Status</th>
+            <th>Next supervisory gate</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>I</td>
+            <td>Inventory, ownership, baseline policies, and evidence taxonomy.</td>
+            <td class="ok">Complete</td>
+            <td>Annual inventory attestation and orphan-system sweep.</td>
+          </tr>
+          <tr>
+            <td>II</td>
+            <td>Model risk, validation, monitoring, and challenger controls.</td>
+            <td class="ok">Complete</td>
+            <td>SR 26-2 delta assessment and GenAI policy overlay.</td>
+          </tr>
+          <tr>
+            <td>III</td>
+            <td>DevSecOps, supply chain, CI/CD enforcement, and WORM logs.</td>
+            <td class="ok">Complete</td>
+            <td>Release-provenance sampling and critical-vulnerability closure test.</td>
+          </tr>
+          <tr>
+            <td>IV</td>
+            <td>Enterprise AIMS, cross-regulatory mappings, and conduct-risk controls.</td>
+            <td class="ok">Complete</td>
+            <td>ISO/IEC 42001 management review and independent audit.</td>
+          </tr>
+          <tr>
+            <td>V</td>
+            <td>Resilience, third-party oversight, crisis simulation, and regulatory APIs.</td>
+            <td class="watch">In progress</td>
+            <td>DORA/NIS2 incident exercise with AI platform failure injects.</td>
+          </tr>
+          <tr>
+            <td>VI-δ</td>
+            <td>Sentinel v2.4, Omni-Sentinel Mesh v4.0, SCP v3.0, and treaty-grade supervisory exchange.</td>
+            <td class="watch">Controlled rollout</td>
+            <td>Jurisdictional pilot approval, privacy review, and regulator-observer tabletop.</td>
+          </tr>
+          <tr>
+            <td>Beyond</td>
+            <td>Frontier autonomy, civilizational risk, planetary governance, and post-2035 systemic coordination.</td>
+            <td class="watch">Research track</td>
+            <td>Board-approved horizon-scanning charter and public-interest escalation doctrine.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="sealed">
+      <h2>6. Regulator-Ready Documentation and Sealed Dossier Status</h2>
+      <div class="seal">
+        Dossier ID: GIEN-VI-DELTA-DAILY-20260718<br>
+        Evidence window: 2026-07-17T00:00:00Z / 2026-07-18T00:00:00Z<br>
+        Seal mode: TEMPLATE-READY — replace with institution hash, signer certificate, WORM object ID, and supervisory submission package ID.<br>
+        Required attachments: inventory export, Annex IV technical file, AI RMF control map, AIMS evidence, MRM validation pack,
+        incident ledger, SBOM, CI/CD attestations, third-party register, and records-retention proof.
+      </div>
+    </section>
+
+    <section id="epochs">
+      <h2>7. Retrospective and Forward-Looking Civilizational AI Governance Analysis</h2>
+      <div class="grid">
+        <div class="card">
+          <h3>2026–2035: Institutional hardening</h3>
+          <p>
+            Primary risk is uneven execution: shadow AI, vendor concentration, model interdependence,
+            customer harm, cyber-AI convergence, and inconsistent supervisory evidence. Success requires
+            daily evidence operations, board accountability, and standardized regulator interfaces.
+          </p>
+        </div>
+        <div class="card">
+          <h3>2035–2100+: Systemic coordination</h3>
+          <p>
+            Financial AI governance must evolve from institution-level control testing into planetary
+            critical-infrastructure stewardship: interoperable safety cases, treaty-grade incident exchange,
+            resilience against autonomous manipulation, and auditable public-interest constraints.
+          </p>
+        </div>
+        <div class="card">
+          <h3>Supervisory doctrine</h3>
+          <p>
+            Regulators should examine not only whether controls exist, but whether they remain effective
+            under distribution shift, cyber compromise, market stress, vendor outage, and autonomous-agent escalation.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section id="sources">
+      <h2>8. Reference Anchors and Daily Closure Checklist</h2>
+      <div class="grid">
+        <div class="card">
+          <h3>Primary reference anchors</h3>
+          <ul>
+            <li><a href="https://artificialintelligenceact.eu/annex/4/" rel="noreferrer">EU AI Act Annex IV technical documentation</a></li>
+            <li><a href="https://www.nist.gov/itl/ai-risk-management-framework" rel="noreferrer">NIST AI Risk Management Framework</a></li>
+            <li><a href="https://www.nist.gov/itl/ai-risk-management-framework/generative-ai-profile" rel="noreferrer">NIST AI 600-1 Generative AI Profile</a></li>
+            <li><a href="https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm" rel="noreferrer">Federal Reserve SR 26-2 revised model-risk guidance</a></li>
+            <li><a href="https://eur-lex.europa.eu/eli/reg/2022/2554/oj" rel="noreferrer">EU DORA Regulation</a></li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Daily closure checklist</h3>
+          <ul>
+            <li>Confirm critical AI, model, cyber, privacy, operational-resilience, and customer-outcome alerts are closed or escalated.</li>
+            <li>Verify daily evidence hashes, signer identity, retention class, and regulator-submission readiness.</li>
+            <li>Review exceptions older than policy SLA and require named senior-owner acceptance.</li>
+            <li>Update roadmap risk register and civilizational horizon-scanning notes.</li>
+          </ul>
+        </div>
+      </div>
+      <p class="small">
+        Generated as a static supervisory artifact for the GIEN governance suite. Replace synthetic statuses with
+        institution-specific operational evidence before external submission.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/rag-agentic-dashboard/public/governance-index.html
+++ b/rag-agentic-dashboard/public/governance-index.html
@@ -132,7 +132,8 @@ footer{text-align:center;padding:32px;color:var(--muted);font-size:12px;border-t
 
 <!-- Reports -->
 <div class="section">
-<div class="section-title"><span class="num">6</span>Companion Documents (19 Reports)</div>
+<div class="section-title"><span class="num">6</span>Companion Documents (20 Reports)</div>
+<div class="card"><strong><a href="/gien-phase-vi-delta-supervisory-dossier.html">GIEN Phase VI-δ Daily Supervisory Dossier</a></strong><br><span class="muted">Regulator-ready DevSecOps and AI governance operational verification brief for Sentinel v2.4, Omni-Sentinel Mesh v4.0, and SCP v3.0.</span></div>
 <div class="card" id="reportsCard"><div class="loading">Loading reports...</div></div>
 </div>
 


### PR DESCRIPTION
### Motivation
- Provide a regulator-ready, static daily supervisory dossier template for GIEN Phase VI-δ / Sentinel v2.4 / Omni-Sentinel Mesh v4.0 to support daily DevSecOps and AI-governance evidence packaging.
- Make the new dossier discoverable from the governance landing page so operators and examiners can access the template alongside other companion reports.

### Description
- Add a new static HTML dossier at `rag-agentic-dashboard/public/gien-phase-vi-delta-supervisory-dossier.html` containing a full regulator-ready supervisory brief, multiple verification tables, roadmap, sealed-dossier block, and styling for dark/print modes.
- Update `rag-agentic-dashboard/public/governance-index.html` to increment the Companion Documents count and add a prominent link/card to the new dossier.
- Changes are static-only (HTML/CSS) and do not introduce runtime logic or new backend APIs.

### Testing
- No automated tests were added or modified for this static content change; there were no automated test runs included with this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b1e9b93d483298aa1edc815ed7299)

## Summary by Sourcery

Add and index the GIEN Phase VI-δ daily supervisory dossier for regulator-ready AI governance evidence packaging.

New Features:
- Add a static GIEN Phase VI-δ daily supervisory dossier covering DevSecOps, AI governance, regulatory alignment, operational verification, roadmap status, and sealed evidence packaging.

Enhancements:
- Register the new dossier in the governance index and update the companion-document count.

Documentation:
- Provide a regulator-ready, responsive, dark-mode and print-friendly supervisory documentation artifact with daily evidence and closure guidance.